### PR TITLE
Change internal command line exception classes to package-protected RuntimeExceptions

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineException.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineException.java
@@ -76,8 +76,9 @@ public class CommandLineException extends RuntimeException {
      * Class CommandLineParserInternalException
      * <p/>
      * For internal errors in the command line parser not related to syntax errors in the command line itself.
+     * Package protected to restrict usage to the arg parsers.
      */
-    public static class CommandLineParserInternalException extends CommandLineException {
+    static class CommandLineParserInternalException extends RuntimeException {
         private static final long serialVersionUID = 0L;
         public CommandLineParserInternalException( final String s ) {
             super(s);
@@ -90,8 +91,9 @@ public class CommandLineException extends RuntimeException {
 
     /**
      * For wrapping errors that are believed to never be reachable
+     * Package protected to restrict usage to the arg parsers.
      */
-    public static class ShouldNeverReachHereException extends CommandLineException {
+    static class ShouldNeverReachHereException extends RuntimeException {
         private static final long serialVersionUID = 0L;
         public ShouldNeverReachHereException( final String s ) {
             super(s);
@@ -99,7 +101,7 @@ public class CommandLineException extends RuntimeException {
         public ShouldNeverReachHereException( final String s, final Throwable throwable ) {
             super(s, throwable);
         }
-        public ShouldNeverReachHereException( final Throwable throwable) {this("Should never reach here.", throwable);}
+        public ShouldNeverReachHereException( final Throwable throwable) {this("Barclay command line parser; should never reach here.", throwable);}
     }
 
 }

--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineException.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineException.java
@@ -76,9 +76,8 @@ public class CommandLineException extends RuntimeException {
      * Class CommandLineParserInternalException
      * <p/>
      * For internal errors in the command line parser not related to syntax errors in the command line itself.
-     * Package protected to restrict usage to the arg parsers.
      */
-    static class CommandLineParserInternalException extends RuntimeException {
+    public static class CommandLineParserInternalException extends RuntimeException {
         private static final long serialVersionUID = 0L;
         public CommandLineParserInternalException( final String s ) {
             super(s);
@@ -93,7 +92,7 @@ public class CommandLineException extends RuntimeException {
      * For wrapping errors that are believed to never be reachable
      * Package protected to restrict usage to the arg parsers.
      */
-    static class ShouldNeverReachHereException extends RuntimeException {
+    static class ShouldNeverReachHereException extends CommandLineParserInternalException {
         private static final long serialVersionUID = 0L;
         public ShouldNeverReachHereException( final String s ) {
             super(s);


### PR DESCRIPTION
and change their base class to RuntimeException so that all CommandLineExceptions can be treated as user errors.
