### PR TITLE
Use field name in doc when annotation has no arg name.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/DefaultDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/barclay/help/DefaultDocWorkUnitHandler.java
@@ -693,7 +693,7 @@ public class DefaultDocWorkUnitHandler extends DocWorkUnitHandler {
     protected Map<String, Object> docForArgument(final FieldDoc fieldDoc, final CommandLineArgumentParser.ArgumentDefinition def) {
         final Map<String, Object> root = new HashMap<>();
 
-        final Pair<String, String> names = displayNames(def.shortName, def.fullName);
+        final Pair<String, String> names = displayNames(def.shortName, def.getLongName());
         root.put("name", names.getLeft());
         root.put("synonyms", names.getRight() != null ? names.getRight() : "NA");
         root.put("required", def.optional ? "no": "yes") ;

--- a/src/test/java/org/broadinstitute/barclay/help/DocumentationGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/barclay/help/DocumentationGenerationIntegrationTest.java
@@ -51,9 +51,9 @@ public class DocumentationGenerationIntegrationTest {
         Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
                 "org_broadinstitute_barclay_help_TestArgumentContainer.html.json"));
         Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestArgumentContainer.html"));
+                "org_broadinstitute_barclay_help_TestExtraDocs.html"));
         Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestArgumentContainer.html.json"));
+                "org_broadinstitute_barclay_help_TestExtraDocs.html.json"));
     }
 
     public boolean filesContentsIdentical(

--- a/src/test/java/org/broadinstitute/barclay/help/TestArgumentContainer.java
+++ b/src/test/java/org/broadinstitute/barclay/help/TestArgumentContainer.java
@@ -127,6 +127,9 @@ public class TestArgumentContainer implements CommandLinePluginProvider {
             doc = "deprecated", optional = true)
     protected int deprecatedString;
 
+    @Argument(doc="Use field name if no name in annotation.")
+    protected String usesFieldNameForArgName;
+
     //////////////////////////////////////////////////////////////////////
     // Embedded argument collection
     @ArgumentCollection

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/org_broadinstitute_barclay_help_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/org_broadinstitute_barclay_help_TestArgumentContainer.html
@@ -159,6 +159,14 @@
 					<td>[]</td>
 					<td>A required list of strings</td>
 				</tr>
+				<tr>
+					<td><a href="#--usesFieldNameForArgName">--usesFieldNameForArgName</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>String</td> -->
+					<td>null</td>
+					<td>Use field name if no name in annotation.</td>
+				</tr>
 			<tr>
 				<th colspan="4" id="row-divider">Optional Tool Arguments</th>
 			</tr>
@@ -551,6 +559,19 @@
 		<p>
 			<span class="label label-info ">List[String]</span>
 				&nbsp;<span class="label">[]</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--usesFieldNameForArgName">--usesFieldNameForArgName </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>Use field name if no name in annotation.</b><br />
+			
+		</p>
+		<p>
+				<span class="badge badge-important">R</span>
+			<span class="label label-info ">String</span>
+				&nbsp;<span class="label">null</span>
 		</p>
 
         <hr>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
@@ -318,6 +318,21 @@
       "maxRecValue": "NA",
       "kind": "optional",
       "options": []
+    },
+    {
+      "summary": "Use field name if no name in annotation.",
+      "name": "--usesFieldNameForArgName",
+      "synonyms": "-",
+      "type": "String",
+      "required": "yes",
+      "fulltext": "",
+      "defaultValue": "null",
+      "minValue": "NA",
+      "maxValue": "NA",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "required",
+      "options": []
     }
   ],
   "description": "Argument container class for testing documentation generation. Contains an argument\n for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should\n be tested.\n\n Test custom tag:\n \n\n \u003cp\u003e\n The purpose of this paragraph is to test embedded html formatting.\n \u003col\u003e\n     \u003cli\u003eThis is point number 1\u003c/li\u003e\n     \u003cli\u003eThis is point number 2\u003c/li\u003e\n \u003c/ol\u003e\n \u003c/p\u003e",


### PR DESCRIPTION
The current doc output contains no argument name if the Argument annotation doesn't specify one, but it should use the field name.

Also fixes the test for JSON doc output, which was redundantly checking the html output file instead of the JSON output file.
