### PR TITLE
Use the simple (unqualified) tool name when displaying a command line.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -1305,7 +1305,7 @@ public final class CommandLineArgumentParser implements CommandLineParser {
     @SuppressWarnings("unchecked")
     @Override
     public String getCommandLine() {
-        final String toolName = callerArguments.getClass().getName();
+        final String toolName = callerArguments.getClass().getSimpleName();
         final StringBuilder commandLineString = new StringBuilder();
 
         final List<Object> positionalArgs;

--- a/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
@@ -353,7 +353,7 @@ public class LegacyCommandLineArgumentParser implements CommandLineParser {
         this.argv = args;
         this.messageStream = messageStream;
         if (prefix.isEmpty()) {
-            commandLine = callerOptions.getClass().getName();
+            commandLine = callerOptions.getClass().getSimpleName();
         }
         for (int i = 0; i < args.length; ++i) {
             final String arg = args[i];

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
@@ -227,7 +227,7 @@ public final class CommandLineArgumentParserTest {
         final CommandLineArgumentParser clp = new CommandLineArgumentParser(fo);
         Assert.assertTrue(clp.parseArguments(System.err, args));
         Assert.assertEquals(clp.getCommandLine(),
-                "org.broadinstitute.barclay.argparser.CommandLineArgumentParserTest$FrobnicateArguments  " +
+                "FrobnicateArguments  " +
                         "positional1 positional2 --FROBNICATION_THRESHOLD 17 --FROBNICATION_FLAVOR BAR " +
                         "--SHMIGGLE_TYPE shmiggle1 --SHMIGGLE_TYPE shmiggle2 --TRUTHINESS true  --help false " +
                         "--version false --showHidden false");

--- a/src/test/java/org/broadinstitute/barclay/argparser/TaggedArgumentTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/TaggedArgumentTest.java
@@ -422,10 +422,10 @@ public class TaggedArgumentTest {
     public Object[][] taggedGetCommandLine() {
         return new Object[][]{
                 {new String[]{"--t:tumor", "gcs://my/tumor.bam"},
-                        "org.broadinstitute.barclay.argparser.TaggedArgumentTest$TaggableArguments  --tFullName:tumor gcs://my/tumor.bam  --tScalar:taggableArgScalar foo --scalarArg 17"
+                        "TaggableArguments  --tFullName:tumor gcs://my/tumor.bam  --tScalar:taggableArgScalar foo --scalarArg 17"
                 },
                 {new String[]{"--t:tumor,truth=false,training=true", "tumor.bam", "--tFullName:normal,truth=true,training=false", "normal.bam"},
-                        "org.broadinstitute.barclay.argparser.TaggedArgumentTest$TaggableArguments  --tFullName:tumor,training=true,truth=false tumor.bam --tFullName:normal,training=false,truth=true normal.bam  --tScalar:taggableArgScalar foo --scalarArg 17"
+                        "TaggableArguments  --tFullName:tumor,training=true,truth=false tumor.bam --tFullName:normal,training=false,truth=true normal.bam  --tScalar:taggableArgScalar foo --scalarArg 17"
                 }
         };
     }
@@ -437,6 +437,5 @@ public class TaggedArgumentTest {
         clp.parseArguments(System.err, argv);
         final String commandLine = clp.getCommandLine();
         Assert.assertEquals(commandLine, expectedCommandLine);
-
     }
 }


### PR DESCRIPTION
Currently when we generate a command line for display purposes, it contains the fully qualified name of the tool/class ("org.broadinstitute.hellbender.tools.PrintReads"). Propose to change it to use the simple name ("PrintReads").