### PR TITLE
Index output extension option

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -219,12 +219,17 @@ public class HelpDoclet {
     /**
      * @return the output extension to use, i.e., ".html" or ".php"
      */
-    protected String getOutputFileExtension() { return outputFileExtension; }
+    public String getOutputFileExtension() { return outputFileExtension; }
 
     /**
      * @return the name of the index template to be used for this doclet
      */
-    protected String getIndexTemplateName() { return "generic.index.template.html"; }
+    public String getIndexTemplateName() { return "generic.index.template.html"; }
+
+    /**
+     * @return the file where the files will be output
+     */
+    public File getDestinationDir() { return  destinationDir; }
 
     /**
      * Determine if a particular class should be included in the output. This is called by the doclet
@@ -332,7 +337,7 @@ public class HelpDoclet {
    ) throws IOException {
         // Get or create a template and merge in the data
         final Template template = cfg.getTemplate(getIndexTemplateName());
-        final File indexFile = new File(destinationDir + "/index." + outputFileExtension);
+        final File indexFile = new File(getDestinationDir() + "/index." + outputFileExtension);
         try (final FileOutputStream fileOutStream = new FileOutputStream(indexFile);
              final OutputStreamWriter outWriter = new OutputStreamWriter(fileOutStream)) {
             template.process(groupIndexMap(workUnitList, groupMaps), outWriter);
@@ -364,8 +369,8 @@ public class HelpDoclet {
 
         root.put("data", data);
         root.put("groups", groupMaps);
-        root.put("timestamp", buildTimestamp);
-        root.put("version", absoluteVersion);
+        root.put("timestamp", getBuildTimeStamp());
+        root.put("version", getBuildVersion());
 
         return root;
     }
@@ -441,7 +446,7 @@ public class HelpDoclet {
         try {
             // Merge data-model with template
             Template template = cfg.getTemplate(workUnit.getTemplateName());
-            File outputPath = new File(destinationDir + "/" + workUnit.getTargetFileName());
+            File outputPath = new File(getDestinationDir() + "/" + workUnit.getTargetFileName());
             try (final Writer out = new OutputStreamWriter(new FileOutputStream(outputPath))) {
                 template.process(workUnit.getRootMap(), out);
             }
@@ -463,7 +468,7 @@ public class HelpDoclet {
         );
 
         // Convert object to JSON and write JSON entry to file
-        File outputPathForJSON = new File(destinationDir + "/" + workUnit.getTargetFileName() + ".json");
+        File outputPathForJSON = new File(getDestinationDir() + "/" + workUnit.getTargetFileName() + ".json");
 
         try (final BufferedWriter jsonWriter = new BufferedWriter(new FileWriter(outputPathForJSON))) {
             Gson gson = new GsonBuilder()

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -234,7 +234,7 @@ public class HelpDoclet {
     /**
      * @return the output extension to use for the index, i.e., ".html" or ".php"
      */
-    public String getIndexFileExtension() { return indexFileExtension; }
+    public String getIndexFileExtension() { return (indexFileExtension == null) ? outputFileExtension : indexFileExtension; }
 
     /**
      * @return the name of the index template to be used for this doclet

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -75,7 +75,7 @@ public class HelpDoclet {
     protected static File settingsDir = DEFAULT_SETTINGS_DIR;
     protected static File destinationDir = DEFAULT_DESTINATION_DIR;
     protected static String outputFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
-    protected static String indexFileExtension = null;
+    protected static String indexFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
     protected static String buildTimestamp = "[no timestamp available]";
     protected static String absoluteVersion = "[no version available]";
     protected static boolean showHiddenFeatures = false;
@@ -91,6 +91,9 @@ public class HelpDoclet {
      * @throws java.io.IOException if output can't be written.
      */
     protected boolean startProcessDocs(final RootDoc rootDoc) throws IOException {
+        // set the indexFileExtension to null to identify if it was provided with -index-file-extension option
+        // this is necessary the make the default the same as the -output-file-extension if it wasn't provided
+        indexFileExtension = null;
         for (String[] options : rootDoc.options()) {
             if (options[0].equals(SETTINGS_DIR_OPTION))
                 settingsDir = new File(options[1]);
@@ -110,7 +113,7 @@ public class HelpDoclet {
             }
         }
 
-        // default to outputFileExtension
+        // default to outputFileExtension if it was not provided
         if (indexFileExtension == null) {
             indexFileExtension = outputFileExtension;
         }
@@ -234,7 +237,7 @@ public class HelpDoclet {
     /**
      * @return the output extension to use for the index, i.e., ".html" or ".php"
      */
-    public String getIndexFileExtension() { return (indexFileExtension == null) ? outputFileExtension : indexFileExtension; }
+    public String getIndexFileExtension() { return (indexFileExtension; }
 
     /**
      * @return the name of the index template to be used for this doclet

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -91,9 +91,6 @@ public class HelpDoclet {
      * @throws java.io.IOException if output can't be written.
      */
     protected boolean startProcessDocs(final RootDoc rootDoc) throws IOException {
-        // set the indexFileExtension to null to identify if it was provided with -index-file-extension option
-        // this is necessary the make the default the same as the -output-file-extension if it wasn't provided
-        indexFileExtension = null;
         for (String[] options : rootDoc.options()) {
             if (options[0].equals(SETTINGS_DIR_OPTION))
                 settingsDir = new File(options[1]);
@@ -111,11 +108,6 @@ public class HelpDoclet {
             if (options[0].equals(INDEX_FILE_EXTENSION_OPTION)) {
                 indexFileExtension = options[1];
             }
-        }
-
-        // default to outputFileExtension if it was not provided
-        if (indexFileExtension == null) {
-            indexFileExtension = outputFileExtension;
         }
 
         if (!settingsDir.exists())

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -58,6 +58,7 @@ public class HelpDoclet {
     final private static String ABSOLUTE_VERSION_OPTION = "-absolute-version";
     final private static String INCLUDE_HIDDEN_OPTION = "-hidden-version";
     final private static String OUTPUT_FILE_EXTENSION_OPTION = "-output-file-extension";
+    final private static String INDEX_FILE_EXTENSION_OPTION = "-index-file-extension";
 
     // Where we find the help FreeMarker templates
     final private static File DEFAULT_SETTINGS_DIR = new File("settings/helpTemplates");
@@ -74,6 +75,7 @@ public class HelpDoclet {
     protected static File settingsDir = DEFAULT_SETTINGS_DIR;
     protected static File destinationDir = DEFAULT_DESTINATION_DIR;
     protected static String outputFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
+    protected static String indexFileExtension = null;
     protected static String buildTimestamp = "[no timestamp available]";
     protected static String absoluteVersion = "[no version available]";
     protected static boolean showHiddenFeatures = false;
@@ -103,6 +105,14 @@ public class HelpDoclet {
             if (options[0].equals(OUTPUT_FILE_EXTENSION_OPTION)) {
                 outputFileExtension = options[1];
             }
+            if (options[0].equals(INDEX_FILE_EXTENSION_OPTION)) {
+                indexFileExtension = options[1];
+            }
+        }
+
+        // default to outputFileExtension
+        if (indexFileExtension == null) {
+            indexFileExtension = outputFileExtension;
         }
 
         if (!settingsDir.exists())
@@ -222,6 +232,11 @@ public class HelpDoclet {
     public String getOutputFileExtension() { return outputFileExtension; }
 
     /**
+     * @return the output extension to use for the index, i.e., ".html" or ".php"
+     */
+    public String getIndexFileExtension() { return indexFileExtension; }
+
+    /**
      * @return the name of the index template to be used for this doclet
      */
     public String getIndexTemplateName() { return "generic.index.template.html"; }
@@ -337,7 +352,7 @@ public class HelpDoclet {
    ) throws IOException {
         // Get or create a template and merge in the data
         final Template template = cfg.getTemplate(getIndexTemplateName());
-        final File indexFile = new File(getDestinationDir() + "/index." + outputFileExtension);
+        final File indexFile = new File(getDestinationDir() + "/index." + getIndexFileExtension());
         try (final FileOutputStream fileOutStream = new FileOutputStream(indexFile);
              final OutputStreamWriter outWriter = new OutputStreamWriter(fileOutStream)) {
             template.process(groupIndexMap(workUnitList, groupMaps), outWriter);

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -237,7 +237,7 @@ public class HelpDoclet {
     /**
      * @return the output extension to use for the index, i.e., ".html" or ".php"
      */
-    public String getIndexFileExtension() { return (indexFileExtension; }
+    public String getIndexFileExtension() { return indexFileExtension; }
 
     /**
      * @return the name of the index template to be used for this doclet


### PR DESCRIPTION
Includes the following changes:

- Make public some getters and implement new ones. This will be helpful for DocWorkUnitHandler implementations.
- Use getters within the class to use overriden ones from sub-classes.
- New option and field (including getter) for different index extension, which default outputFileExtension.

Close #59 