### PR TITLE
Don't require no-arg constructors for DocumentedFeatures.

### DIFF
--- a/src/test/java/org/broadinstitute/barclay/argparser/TestProgramGroup.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/TestProgramGroup.java
@@ -6,11 +6,11 @@ package org.broadinstitute.barclay.argparser;
 public final class TestProgramGroup implements CommandLineProgramGroup {
     @Override
     public String getName() {
-        return "Testing";
+        return "TestProgramGroup";
     }
 
     @Override
     public String getDescription() {
-        return "group used for testing";
+        return "Test program group used for testing";
     }
 }

--- a/src/test/java/org/broadinstitute/barclay/help/TestExtraDocs.java
+++ b/src/test/java/org/broadinstitute/barclay/help/TestExtraDocs.java
@@ -5,7 +5,7 @@ import org.broadinstitute.barclay.argparser.Argument;
 /**
  * Class for testing extraDocs property in docgen.
  */
-@DocumentedFeature(groupName = "Test extra docs group name", extraDocs = TestExtraDocs.class)
+@DocumentedFeature(groupName = "Test extra docs group name")
 public class TestExtraDocs {
 
     @Argument(fullName = "extraDocsArgument",

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/index.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/index.html
@@ -45,7 +45,7 @@
         </div>
         <div class="accordion-body collapse" id="Testfeaturegroupname">
             <div class="accordion-inner">
-                <p class="lead">group used for testing</p>
+                <p class="lead">Test program group used for testing</p>
                 <table class="table table-striped table-bordered table-condensed">
                     <tr>
                         <th>Name</th>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html
@@ -63,54 +63,8 @@
 		<h2>Overview</h2>
 		Class for testing extraDocs property in docgen.
 
-				<hr>
-				<h2>Command-line Arguments</h2>
-				<p></p>
-				<h3>Additional References</h3>
-				<p>See these additional references for more information.</p>
-				<ul>
-						<li><a href="org_broadinstitute_barclay_help_TestExtraDocs.html">TestExtraDocs</a></li>
-				</ul>
 
-				<h3>TestExtraDocs specific arguments</h3>
-				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
-				<table class="table table-striped table-bordered table-condensed">
-					<thead>
-					<tr>
-						<th>Argument name(s)</th>
-						<th>Default value</th>
-						<th>Summary</th>
-					</tr>
-					</thead>
-					<tbody>
-			<tr>
-				<th colspan="4" id="row-divider">Optional Tool Arguments</th>
-			</tr>
-				<tr>
-					<td><a href="#--extraDocsArgument">--extraDocsArgument</a><br />
-								&nbsp;<em>-extDocArg</em>
-					</td>
-					<!--<td>String</td> -->
-					<td>initial string value</td>
-					<td>Extra stuff</td>
-				</tr>
-					</tbody>
-				</table>
 
-					<h3>Argument details</h3>
-					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
-		<hr style="border-bottom: dotted 1px #C0C0C0;" />
-		<h3><a name="--extraDocsArgument">--extraDocsArgument </a>
-			 / <small>-extDocArg</small>
-		</h3>
-		<p class="args">
-			<b>Extra stuff</b><br />
-			
-		</p>
-		<p>
-			<span class="label label-info ">String</span>
-				&nbsp;<span class="label">initial string value</span>
-		</p>
 
         <hr>
         <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html.json
@@ -1,22 +1,5 @@
 {
   "summary": "Class for testing extraDocs property in docgen.",
-  "arguments": [
-    {
-      "summary": "Extra stuff",
-      "name": "--extraDocsArgument",
-      "synonyms": "-extDocArg",
-      "type": "String",
-      "required": "no",
-      "fulltext": "",
-      "defaultValue": "initial string value",
-      "minValue": "NA",
-      "maxValue": "NA",
-      "minRecValue": "NA",
-      "maxRecValue": "NA",
-      "kind": "optional",
-      "options": []
-    }
-  ],
   "description": "Class for testing extraDocs property in docgen.",
   "name": "TestExtraDocs",
   "group": "Test extra docs group name"

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/index.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/index.html
@@ -48,7 +48,7 @@
         </div>
         <div class="accordion-body collapse" id="Testfeaturegroupname">
             <div class="accordion-inner">
-                <p class="lead">group used for testing</p>
+                <p class="lead">Test program group used for testing</p>
                 <table class="table table-striped table-bordered table-condensed">
                     <tr>
                         <th>Name</th>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html
@@ -67,54 +67,8 @@
 		<h2>Overview</h2>
 		Class for testing extraDocs property in docgen.
 
-				<hr>
-				<h2>Command-line Arguments</h2>
-				<p></p>
-				<h3>Additional References</h3>
-				<p>See these additional references for more information.</p>
-				<ul>
-						<li><a href="org_broadinstitute_barclay_help_TestExtraDocs.html">TestExtraDocs</a></li>
-				</ul>
 
-				<h3>TestExtraDocs specific arguments</h3>
-				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
-				<table class="table table-striped table-bordered table-condensed">
-					<thead>
-					<tr>
-						<th>Argument name(s)</th>
-						<th>Default value</th>
-						<th>Summary</th>
-					</tr>
-					</thead>
-					<tbody>
-			<tr>
-				<th colspan="4" id="row-divider">Optional Tool Arguments</th>
-			</tr>
-				<tr>
-					<td><a href="#--extraDocsArgument">--extraDocsArgument</a><br />
-								&nbsp;<em>-extDocArg</em>
-					</td>
-					<!--<td>String</td> -->
-					<td>initial string value</td>
-					<td>Extra stuff</td>
-				</tr>
-					</tbody>
-				</table>
 
-					<h3>Argument details</h3>
-					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
-		<hr style="border-bottom: dotted 1px #C0C0C0;" />
-		<h3><a name="--extraDocsArgument">--extraDocsArgument </a>
-			 / <small>-extDocArg</small>
-		</h3>
-		<p class="args">
-			<b>Extra stuff</b><br />
-			
-		</p>
-		<p>
-			<span class="label label-info ">String</span>
-				&nbsp;<span class="label">initial string value</span>
-		</p>
 
         <hr>
         <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestExtraDocs.html.json
@@ -1,22 +1,5 @@
 {
   "summary": "Class for testing extraDocs property in docgen.",
-  "arguments": [
-    {
-      "summary": "Extra stuff",
-      "name": "--extraDocsArgument",
-      "synonyms": "-extDocArg",
-      "type": "String",
-      "required": "no",
-      "fulltext": "",
-      "defaultValue": "initial string value",
-      "minValue": "NA",
-      "maxValue": "NA",
-      "minRecValue": "NA",
-      "maxRecValue": "NA",
-      "kind": "optional",
-      "options": []
-    }
-  ],
   "description": "Class for testing extraDocs property in docgen.",
   "name": "TestExtraDocs",
   "group": "Test extra docs group name"


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/barclay/issues/63 and https://github.com/broadinstitute/barclay/issues/62 (originally discovered as https://github.com/broadinstitute/gatk-protected/issues/1048). Also removes the ridiculous test case that has an "extraDocs" reference to itself.