### PR TITLE
Markdown integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.apache.logging.log4j:log4j-api:2.3'
     compile 'org.apache.logging.log4j:log4j-core:2.3'
+    compile 'com.atlassian.commonmark:commonmark:0.9.0'
 
     // Get the jdk files we need to run javaDoc. We need to use these during compile, testCompile,
     // test execution, and gatkDoc generation, but we don't want them as part of the runtime

--- a/src/main/java/org/broadinstitute/barclay/help/DocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/barclay/help/DocWorkUnitHandler.java
@@ -1,6 +1,10 @@
 package org.broadinstitute.barclay.help;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.barclay.utils.Utils;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.Renderer;
+import org.commonmark.renderer.html.HtmlRenderer;
 
 import java.io.*;
 import java.util.List;
@@ -11,14 +15,33 @@ import java.util.Map;
  * used for each documented feature, and populates the template property map for that template.
  */
 public abstract class DocWorkUnitHandler {
+    /**
+     * Default Markdown to HTML renderer.
+     */
+    // TODO: add extensions to default renderer?
+    protected static final Renderer DEFAULT_RENDERER = HtmlRenderer.builder().build();
+
     private final HelpDoclet doclet;
+    private final Renderer markdownRenderer;
+
+    // default parser for Markdown formatted documentation
+    // TODO: allow customization of Markdown parser
+    private Parser markdownParser = Parser.builder().build();
 
     /**
      * @param doclet the HelpDoclet driving this documentation run. Can not be null.
      */
     public DocWorkUnitHandler(final HelpDoclet doclet) {
-        Utils.nonNull("Doclet cannot be null");
-        this.doclet = doclet;
+        this(doclet, DEFAULT_RENDERER);
+    }
+
+    /**
+     * @param doclet the HelpDoclet driving this documentation run. Can not be null.
+     * @param markdownRenderer renderer for rendering markdown formatted strings. Can not be null.
+     */
+    public DocWorkUnitHandler(final HelpDoclet doclet, final Renderer markdownRenderer) {
+       this.doclet = Utils.nonNull(doclet, "Doclet cannot be null");
+       this.markdownRenderer = Utils.nonNull(markdownRenderer, "Renderer cannot be null");
     }
 
     /**
@@ -26,6 +49,24 @@ public abstract class DocWorkUnitHandler {
      */
     public HelpDoclet getDoclet() {
         return doclet;
+    }
+
+    /**
+     * @return rendered markdown string for documentation; empty String if the {@code markdownString} is null or empty.
+     */
+    public final String renderMarkdown(final String markdownString) {
+        if (markdownString == null || markdownString.isEmpty()) {
+            return "";
+        }
+        // render the String and remove the end of line added by the parser/renderer
+        final String renderedString = StringUtils.stripEnd(markdownRenderer.render(markdownParser.parse(markdownString)), "\n");
+        // Markdown parser/renderer adds always a <p></p> around the parsed String even if it is a single line
+        // but we do not want this in single line documentation
+        // TODO: commonmark should have a way to remove this behaviour from the parser/renderer
+        if (!renderedString.contains("\n")) {
+            return StringUtils.removePattern(renderedString, "^<p>|</p>$");
+        }
+        return renderedString;
     }
 
     /**
@@ -57,12 +98,12 @@ public abstract class DocWorkUnitHandler {
 
     /**
      * Apply any fallback rules to determine the summary line that should be used for the work unit.
-     * Default implementation uses the value from the DocumentedFeature annotation.
+     * Default implementation uses the value from the DocumentedFeature annotation, rendered with {@link #renderMarkdown(String)}.
      * @param workUnit
      * @return Summary for this work unit.
      */
     public String getSummaryForWorkUnit(final DocWorkUnit workUnit) {
-        return workUnit.getDocumentedFeature().summary();
+        return renderMarkdown(workUnit.getDocumentedFeature().summary());
     }
 
     /**
@@ -77,12 +118,12 @@ public abstract class DocWorkUnitHandler {
 
     /**
      * Apply any fallback rules to determine the group summary line that should be used for the work unit.
-     * Default implementation uses the value from the DocumentedFeature annotation.
+     * Default implementation uses the value from the DocumentedFeature annotation, rendered with {@link #renderMarkdown(String)}.
      * @param workUnit
      * @return Group summary to be used for this work unit.
      */
     public String getGroupSummaryForWorkUnit(final DocWorkUnit workUnit) {
-        return workUnit.getDocumentedFeature().groupSummary();
+        return renderMarkdown(workUnit.getDocumentedFeature().groupSummary());
     }
 
 }

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
@@ -715,6 +715,30 @@ public final class CommandLineArgumentParserTest {
         return out.toString();
     }
 
+    @CommandLineProgramProperties(
+            summary = "Tool with [Markdown](https://daringfireball.net/projects/markdown/) formatted docs",
+            oneLineSummary = "Tool with Markdown formatted docs",
+            programGroup = TestProgramGroup.class
+    )
+    public class MarkdownFormattedDocs {
+        @Argument(doc = "`String` **BOLD** __argument__", optional = true)
+        public String bold = "";
+
+        @Argument(doc = "`String` *ITALIC* _argument_", optional = true)
+        public String italic = "";
+    }
+
+    @Test
+    public void testMarkdownToTextUsage() {
+        final CommandLineArgumentParser clp = new CommandLineArgumentParser(new MarkdownFormattedDocs());
+        final String usage = clp.usage(false, false);
+        // [text](link) is rendered as quoted text plus link in parenthesis
+        Assert.assertTrue(usage.contains("Tool with \"Markdown\" (https://daringfireball.net/projects/markdown/) formatted docs"));
+        // Italic/Bold is rendered as normal text, backtick is rendered as quoted string
+        Assert.assertTrue(usage.contains("\"String\" BOLD argument"));
+        Assert.assertTrue(usage.contains("\"String\" ITALIC argument"));
+    }
+
 
     @CommandLineProgramProperties(
             summary = "tool with nullable arguments",

--- a/src/test/java/org/broadinstitute/barclay/help/ClpWithMarkdownDocs.java
+++ b/src/test/java/org/broadinstitute/barclay/help/ClpWithMarkdownDocs.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Gómez-Sánchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.broadinstitute.barclay.help;
+
+import org.broadinstitute.barclay.argparser.Argument;
+import org.broadinstitute.barclay.argparser.ArgumentCollection;
+import org.broadinstitute.barclay.argparser.CommandLineProgramProperties;
+import org.broadinstitute.barclay.argparser.TestProgramGroup;
+
+/**
+ * Documentation of this tool is written in Markdown and rendered as HTML.
+ *
+ * ## Javadoc formatted with Markdown
+ *
+ * The purpose of this paragraph is to test embedded [Markdown](https://daringfireball.net/projects/markdown/) formatting:
+ *
+ * - First element of list (**bold**)
+ * - Second element of list (_italic_)
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+@CommandLineProgramProperties(
+        summary = "Test tool summary with [Markdown](https://daringfireball.net/projects/markdown/) formatted docs",
+        oneLineSummary = "Tool where the documentation is formatted with [Markdown](https://daringfireball.net/projects/markdown/) `String`.",
+        programGroup = TestProgramGroup.class)
+@DocumentedFeature(groupName = MarkdownDocumentedFeature.markdownGroup, groupSummary = MarkdownDocumentedFeature.markdownGroupSummary)
+public class ClpWithMarkdownDocs {
+
+    @Argument(doc = "This is a **bold** `String` __argument__")
+    public String bold = "";
+
+    @Argument(doc = "This is a *italic* `String` _argument_")
+    public String italic = "";
+
+    @ArgumentCollection(doc = "Argument collection with [Markdown](https://daringfireball.net/projects/markdown/) formatted docs")
+    public MarkdownArgumentCollection argumentCollection = new MarkdownArgumentCollection();
+
+}

--- a/src/test/java/org/broadinstitute/barclay/help/DocumentationGenerationIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/barclay/help/DocumentationGenerationIntegrationTest.java
@@ -30,6 +30,13 @@ public class DocumentationGenerationIntegrationTest {
             "-cp", System.getProperty("java.class.path")
     );
 
+    private static final List<String> PHP_DOCUMENTED_CLASS_NAMES = Arrays.asList(
+            "org_broadinstitute_barclay_help_TestArgumentContainer",
+            "org_broadinstitute_barclay_help_TestExtraDocs",
+            "org_broadinstitute_barclay_help_MarkdownDocumentedFeature",
+            "org_broadinstitute_barclay_help_ClpWithMarkdownDocs"
+    );
+
     private static String[] docArgList(final Class<?> docletClass, final File templatesFolder, final File outputDir) {
         // set the common arguments
         final List<String> docArgList = new ArrayList<>(COMMON_DOC_ARG_LIST);
@@ -66,14 +73,12 @@ public class DocumentationGenerationIntegrationTest {
 
         // Compare output files
         Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir, "index.html"));
-        Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestArgumentContainer.html"));
-        Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestArgumentContainer.html.json"));
-        Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestExtraDocs.html"));
-        Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
-                "org_broadinstitute_barclay_help_TestExtraDocs.html.json"));
+        for (final String documentedClass: PHP_DOCUMENTED_CLASS_NAMES) {
+            Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
+                    documentedClass +".html"));
+            Assert.assertTrue(filesContentsIdentical(outputDir, expectedDir,
+                    documentedClass +".html.json"));
+        }
     }
 
     private boolean filesContentsIdentical(

--- a/src/test/java/org/broadinstitute/barclay/help/MarkdownArgumentCollection.java
+++ b/src/test/java/org/broadinstitute/barclay/help/MarkdownArgumentCollection.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Gómez-Sánchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.broadinstitute.barclay.help;
+
+import org.broadinstitute.barclay.argparser.Argument;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class MarkdownArgumentCollection {
+
+    @Argument(doc = "This is an `int` argument with markdown formatted doc")
+    public int INT = 0;
+
+    @Argument(doc = "This is an `double` argument with markdown formatted doc")
+    public double DOUBLE = 0;
+}

--- a/src/test/java/org/broadinstitute/barclay/help/MarkdownDocumentedFeature.java
+++ b/src/test/java/org/broadinstitute/barclay/help/MarkdownDocumentedFeature.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Daniel Gómez-Sánchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.broadinstitute.barclay.help;
+
+/**
+ * Documentation of this feature is written in Markdown and rendered as HTML.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+@DocumentedFeature(groupName = MarkdownDocumentedFeature.markdownGroup,
+        groupSummary = MarkdownDocumentedFeature.markdownGroupSummary,
+        summary = "Documented feature formatted with [Markdown](https://daringfireball.net/projects/markdown/).")
+public class MarkdownDocumentedFeature {
+    public static final String markdownGroup = "markdown";
+    public static final String markdownGroupSummary = "**_Markdonw_ Group Summary in bold**";
+}

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/index.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/index.html
@@ -17,6 +17,32 @@
 <div class="accordion" id="index">
     <div class="accordion-group">
         <div class="accordion-heading">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#markdown">
+                <h4>markdown</h4>
+            </a>
+        </div>
+        <div class="accordion-body collapse" id="markdown">
+            <div class="accordion-inner">
+                <p class="lead"><strong><em>Markdonw</em> Group Summary in bold</strong></p>
+                <table class="table table-striped table-bordered table-condensed">
+                    <tr>
+                        <th>Name</th>
+                        <th>Summary</th>
+                    </tr>
+                            <tr>
+                                    <td><a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs **BETA**</a></td>
+                                <td>Tool where the documentation is formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a> <code>String</code>.</td>
+                            </tr>
+                            <tr>
+                                    <td><a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature **BETA**</a></td>
+                                <td>Documented feature formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>.</td>
+                            </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="accordion-group">
+        <div class="accordion-heading">
             <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#Testextradocsgroupname">
                 <h4>Test extra docs group name</h4>
             </a>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html
@@ -1,0 +1,201 @@
+<?php
+    include '../../../common/include/common.php';
+?>
+
+<div class='row-fluid' id="top">
+
+	
+
+	<?php $group = 'markdown'; ?>
+
+	<section class="span4">
+		<aside class="well">
+			<a href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+		</aside>
+		<aside class="well">
+			<h2>Categories</h2>
+        <style>
+            #sidenav .accordion-body a {
+                color : gray;
+            }
+
+            .accordion-body li {
+                list-style : none;
+            }
+        </style>
+        <ul class="nav nav-pills nav-stacked" id="sidenav">
+				<li><a data-toggle="collapse" data-parent="#sidenav" href="#markdown">markdown</a>
+					<div id="markdown"
+					<?php echo ($group == 'markdown')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+					<ul>
+								<li>
+									<a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs</a>
+								</li>
+								<li>
+									<a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature</a>
+								</li>
+					</ul>
+					</div>
+				</li>
+				<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testextradocsgroupname">Test extra docs group name</a>
+					<div id="Testextradocsgroupname"
+					<?php echo ($group == 'Test extra docs group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+					<ul>
+								<li>
+									<a href="org_broadinstitute_barclay_help_TestExtraDocs.html">TestExtraDocs</a>
+								</li>
+					</ul>
+					</div>
+				</li>
+				<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testfeaturegroupname">Test feature group name</a>
+					<div id="Testfeaturegroupname"
+					<?php echo ($group == 'Test feature group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+					<ul>
+								<li>
+									<a href="org_broadinstitute_barclay_help_TestArgumentContainer.html">TestArgumentContainer</a>
+								</li>
+					</ul>
+					</div>
+				</li>
+        </ul>
+		</aside>
+		<?php getForumPosts( 'ClpWithMarkdownDocs' ) ?>
+
+	</section>
+
+	<div class="span8">
+
+			<h1>ClpWithMarkdownDocs **BETA**</h1>
+
+		<p class="lead">Tool where the documentation is formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a> <code>String</code>.</p>
+
+			<h3>Category
+				<small> markdown</small>
+			</h3>
+		<hr>
+		<h2>Overview</h2>
+		<p>Documentation of this tool is written in Markdown and rendered as HTML.</p>
+<h2>Javadoc formatted with Markdown</h2>
+<p>The purpose of this paragraph is to test embedded <a href="https://daringfireball.net/projects/markdown/">Markdown</a> formatting:</p>
+<ul>
+<li>First element of list (<strong>bold</strong>)</li>
+<li>Second element of list (<em>italic</em>)</li>
+</ul>
+
+				<hr>
+				<h2>Command-line Arguments</h2>
+				<p></p>
+
+				<h3>ClpWithMarkdownDocs specific arguments</h3>
+				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
+				<table class="table table-striped table-bordered table-condensed">
+					<thead>
+					<tr>
+						<th>Argument name(s)</th>
+						<th>Default value</th>
+						<th>Summary</th>
+					</tr>
+					</thead>
+					<tbody>
+			<tr>
+				<th colspan="4" id="row-divider">Optional Tool Arguments</th>
+			</tr>
+				<tr>
+					<td><a href="#--bold">--bold</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>String</td> -->
+					<td>""</td>
+					<td>This is a <strong>bold</strong> <code>String</code> <strong>argument</strong></td>
+				</tr>
+				<tr>
+					<td><a href="#--DOUBLE">--DOUBLE</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>double</td> -->
+					<td>0.0</td>
+					<td>This is an <code>double</code> argument with markdown formatted doc</td>
+				</tr>
+				<tr>
+					<td><a href="#--INT">--INT</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>int</td> -->
+					<td>0</td>
+					<td>This is an <code>int</code> argument with markdown formatted doc</td>
+				</tr>
+				<tr>
+					<td><a href="#--italic">--italic</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>String</td> -->
+					<td>""</td>
+					<td>This is a <em>italic</em> <code>String</code> <em>argument</em></td>
+				</tr>
+					</tbody>
+				</table>
+
+					<h3>Argument details</h3>
+					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--bold">--bold </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is a <strong>bold</strong> <code>String</code> <strong>argument</strong></b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">String</span>
+				&nbsp;<span class="label">""</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--DOUBLE">--DOUBLE </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is an <code>double</code> argument with markdown formatted doc</b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">double</span>
+				&nbsp;<span class="label">0.0</span>
+				&nbsp;<span class="label label-warning">[ [ -∞</span>
+				&nbsp;<span class="label label-warning">∞ ] ]</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--INT">--INT </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is an <code>int</code> argument with markdown formatted doc</b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">int</span>
+				&nbsp;<span class="label">0</span>
+				&nbsp;<span class="label label-warning">[ [ -∞</span>
+				&nbsp;<span class="label label-warning">∞ ] ]</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--italic">--italic </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is a <em>italic</em> <code>String</code> <em>argument</em></b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">String</span>
+				&nbsp;<span class="label">""</span>
+		</p>
+
+        <hr>
+        <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>
+        <hr>
+        <p class="version">Barclay version 11.1 built at 2016/01/01 01:01:01.
+        </p>
+
+	</div>
+
+	<?php printFooter($module); ?>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html.json
@@ -1,0 +1,68 @@
+{
+  "summary": "Tool where the documentation is formatted with \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e \u003ccode\u003eString\u003c/code\u003e.",
+  "arguments": [
+    {
+      "summary": "This is a \u003cstrong\u003ebold\u003c/strong\u003e \u003ccode\u003eString\u003c/code\u003e \u003cstrong\u003eargument\u003c/strong\u003e",
+      "name": "--bold",
+      "synonyms": "-",
+      "type": "String",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "\"\"",
+      "minValue": "NA",
+      "maxValue": "NA",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is an \u003ccode\u003edouble\u003c/code\u003e argument with markdown formatted doc",
+      "name": "--DOUBLE",
+      "synonyms": "-",
+      "type": "double",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "0.0",
+      "minValue": "-Infinity",
+      "maxValue": "Infinity",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is an \u003ccode\u003eint\u003c/code\u003e argument with markdown formatted doc",
+      "name": "--INT",
+      "synonyms": "-",
+      "type": "int",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "0",
+      "minValue": "-Infinity",
+      "maxValue": "Infinity",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is a \u003cem\u003eitalic\u003c/em\u003e \u003ccode\u003eString\u003c/code\u003e \u003cem\u003eargument\u003c/em\u003e",
+      "name": "--italic",
+      "synonyms": "-",
+      "type": "String",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "\"\"",
+      "minValue": "NA",
+      "maxValue": "NA",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    }
+  ],
+  "description": "\u003cp\u003eDocumentation of this tool is written in Markdown and rendered as HTML.\u003c/p\u003e\n\u003ch2\u003eJavadoc formatted with Markdown\u003c/h2\u003e\n\u003cp\u003eThe purpose of this paragraph is to test embedded \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e formatting:\u003c/p\u003e\n\u003cul\u003e\n\u003cli\u003eFirst element of list (\u003cstrong\u003ebold\u003c/strong\u003e)\u003c/li\u003e\n\u003cli\u003eSecond element of list (\u003cem\u003eitalic\u003c/em\u003e)\u003c/li\u003e\n\u003c/ul\u003e",
+  "name": "ClpWithMarkdownDocs",
+  "group": "markdown"
+}

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html
@@ -6,7 +6,7 @@
 
 	
 
-	<?php $group = 'Test extra docs group name'; ?>
+	<?php $group = 'markdown'; ?>
 
 	<section class="span4">
 		<aside class="well">
@@ -59,22 +59,22 @@
 				</li>
         </ul>
 		</aside>
-		<?php getForumPosts( 'TestExtraDocs' ) ?>
+		<?php getForumPosts( 'MarkdownDocumentedFeature' ) ?>
 
 	</section>
 
 	<div class="span8">
 
-			<h1>TestExtraDocs **BETA**</h1>
+			<h1>MarkdownDocumentedFeature **BETA**</h1>
 
-		<p class="lead">Class for testing extraDocs property in docgen.</p>
+		<p class="lead">Documented feature formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>.</p>
 
 			<h3>Category
-				<small> Test extra docs group name</small>
+				<small> markdown</small>
 			</h3>
 		<hr>
 		<h2>Overview</h2>
-		Class for testing extraDocs property in docgen.
+		Documentation of this feature is written in Markdown and rendered as HTML.
 
 
 

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Documented feature formatted with \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e.",
+  "description": "Documentation of this feature is written in Markdown and rendered as HTML.",
+  "name": "MarkdownDocumentedFeature",
+  "group": "markdown"
+}

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
@@ -24,6 +24,19 @@
             }
         </style>
         <ul class="nav nav-pills nav-stacked" id="sidenav">
+				<li><a data-toggle="collapse" data-parent="#sidenav" href="#markdown">markdown</a>
+					<div id="markdown"
+					<?php echo ($group == 'markdown')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+					<ul>
+								<li>
+									<a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs</a>
+								</li>
+								<li>
+									<a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature</a>
+								</li>
+					</ul>
+					</div>
+				</li>
 				<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testextradocsgroupname">Test extra docs group name</a>
 					<div id="Testextradocsgroupname"
 					<?php echo ($group == 'Test extra docs group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
@@ -61,14 +74,10 @@
 			</h3>
 		<hr>
 		<h2>Overview</h2>
-		Argument container class for testing documentation generation. Contains an argument
- for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should
- be tested.
-
- Test custom tag:
- testType
-
- <p>
+		<p>Argument container class for testing documentation generation. Contains an argument
+for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should
+be tested.</p>
+<p>Test custom tag:</p>testType <p>
  The purpose of this paragraph is to test embedded html formatting.
  <ol>
      <li>This is point number 1</li>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
@@ -335,7 +335,7 @@
       "options": []
     }
   ],
-  "description": "Argument container class for testing documentation generation. Contains an argument\n for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should\n be tested.\n\n Test custom tag:\n testType\n\n \u003cp\u003e\n The purpose of this paragraph is to test embedded html formatting.\n \u003col\u003e\n     \u003cli\u003eThis is point number 1\u003c/li\u003e\n     \u003cli\u003eThis is point number 2\u003c/li\u003e\n \u003c/ol\u003e\n \u003c/p\u003e",
+  "description": "\u003cp\u003eArgument container class for testing documentation generation. Contains an argument\nfor each @Argument, @ArgumentCollection, and @DocumentedFeature property that should\nbe tested.\u003c/p\u003e\n\u003cp\u003eTest custom tag:\u003c/p\u003etestType \u003cp\u003e\n The purpose of this paragraph is to test embedded html formatting.\n \u003col\u003e\n     \u003cli\u003eThis is point number 1\u003c/li\u003e\n     \u003cli\u003eThis is point number 2\u003c/li\u003e\n \u003c/ol\u003e\n \u003c/p\u003e",
   "name": "TestArgumentContainer",
   "group": "Test feature group name"
 }

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/index.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/index.html
@@ -20,6 +20,32 @@
 		<br />
     <div class="accordion-group">
         <div class="accordion-heading">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#markdown">
+                <h4>markdown</h4>
+            </a>
+        </div>
+        <div class="accordion-body collapse" id="markdown">
+            <div class="accordion-inner">
+                <p class="lead"><strong><em>Markdonw</em> Group Summary in bold</strong></p>
+                <table class="table table-striped table-bordered table-condensed">
+                    <tr>
+                        <th>Name</th>
+                        <th>Summary</th>
+                    </tr>
+                            <tr>
+                                    <td><a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs **BETA**</a></td>
+                                <td>Tool where the documentation is formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a> <code>String</code>.</td>
+                            </tr>
+                            <tr>
+                                    <td><a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature **BETA**</a></td>
+                                <td>Documented feature formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>.</td>
+                            </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="accordion-group">
+        <div class="accordion-heading">
             <a class="accordion-toggle" data-toggle="collapse" data-parent="#index" href="#Testextradocsgroupname">
                 <h4>Test extra docs group name</h4>
             </a>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html
@@ -1,0 +1,205 @@
+<?php
+    include '../../../common/include/common.php';
+?>
+
+<div class='row-fluid' id="top">
+
+	
+
+	<?php $group = 'markdown'; ?>
+
+	<section class="span4">
+		<aside class="well">
+			<a href="index"><h4><i class='fa fa-chevron-left'></i> Back to Tool Docs Index</h4></a>
+		</aside>
+		<aside class="well">
+			<h2>Categories</h2>
+        <style>
+            #sidenav .accordion-body a {
+                color : gray;
+            }
+
+            .accordion-body li {
+                list-style : none;
+            }
+        </style>
+        <ul class="nav nav-pills nav-stacked" id="sidenav">
+        		<hr>
+        		<hr>
+        		<hr>
+						<li><a data-toggle="collapse" data-parent="#sidenav" href="#markdown">markdown</a>
+							<div id="markdown"
+								<?php echo ($group == 'markdown')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+								<ul>
+											<li>
+												<a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs</a>
+											</li>
+											<li>
+												<a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature</a>
+											</li>
+								</ul>
+							</div>
+						</li>
+						<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testextradocsgroupname">Test extra docs group name</a>
+							<div id="Testextradocsgroupname"
+								<?php echo ($group == 'Test extra docs group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+								<ul>
+											<li>
+												<a href="org_broadinstitute_barclay_help_TestExtraDocs.html">TestExtraDocs</a>
+											</li>
+								</ul>
+							</div>
+						</li>
+						<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testfeaturegroupname">Test feature group name</a>
+							<div id="Testfeaturegroupname"
+								<?php echo ($group == 'Test feature group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+								<ul>
+											<li>
+												<a href="org_broadinstitute_barclay_help_TestArgumentContainer.html">TestArgumentContainer</a>
+											</li>
+								</ul>
+							</div>
+						</li>
+        		<hr>
+        </ul>
+		</aside>
+		<?php getForumPosts( 'ClpWithMarkdownDocs' ) ?>
+
+	</section>
+
+	<div class="span8">
+
+			<h1>ClpWithMarkdownDocs **BETA**</h1>
+
+		<p class="lead">Tool where the documentation is formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a> <code>String</code>.</p>
+
+			<h3>Category
+				<small> markdown</small>
+			</h3>
+		<hr>
+		<h2>Overview</h2>
+		<p>Documentation of this tool is written in Markdown and rendered as HTML.</p>
+<h2>Javadoc formatted with Markdown</h2>
+<p>The purpose of this paragraph is to test embedded <a href="https://daringfireball.net/projects/markdown/">Markdown</a> formatting:</p>
+<ul>
+<li>First element of list (<strong>bold</strong>)</li>
+<li>Second element of list (<em>italic</em>)</li>
+</ul>
+
+				<hr>
+				<h2>Command-line Arguments</h2>
+				<p></p>
+
+				<h3>ClpWithMarkdownDocs specific arguments</h3>
+				<p>This table summarizes the command-line arguments that are specific to this tool. For more details on each argument, see the list further down below the table or click on an argument name to jump directly to that entry in the list.</p>
+				<table class="table table-striped table-bordered table-condensed">
+					<thead>
+					<tr>
+						<th>Argument name(s)</th>
+						<th>Default value</th>
+						<th>Summary</th>
+					</tr>
+					</thead>
+					<tbody>
+			<tr>
+				<th colspan="4" id="row-divider">Optional Tool Arguments</th>
+			</tr>
+				<tr>
+					<td><a href="#--bold">--bold</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>String</td> -->
+					<td>""</td>
+					<td>This is a <strong>bold</strong> <code>String</code> <strong>argument</strong></td>
+				</tr>
+				<tr>
+					<td><a href="#--DOUBLE">--DOUBLE</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>double</td> -->
+					<td>0.0</td>
+					<td>This is an <code>double</code> argument with markdown formatted doc</td>
+				</tr>
+				<tr>
+					<td><a href="#--INT">--INT</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>int</td> -->
+					<td>0</td>
+					<td>This is an <code>int</code> argument with markdown formatted doc</td>
+				</tr>
+				<tr>
+					<td><a href="#--italic">--italic</a><br />
+								&nbsp;<em>-</em>
+					</td>
+					<!--<td>String</td> -->
+					<td>""</td>
+					<td>This is a <em>italic</em> <code>String</code> <em>argument</em></td>
+				</tr>
+					</tbody>
+				</table>
+
+					<h3>Argument details</h3>
+					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--bold">--bold </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is a <strong>bold</strong> <code>String</code> <strong>argument</strong></b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">String</span>
+				&nbsp;<span class="label">""</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--DOUBLE">--DOUBLE </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is an <code>double</code> argument with markdown formatted doc</b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">double</span>
+				&nbsp;<span class="label">0.0</span>
+				&nbsp;<span class="label label-warning">[ [ -∞</span>
+				&nbsp;<span class="label label-warning">∞ ] ]</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--INT">--INT </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is an <code>int</code> argument with markdown formatted doc</b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">int</span>
+				&nbsp;<span class="label">0</span>
+				&nbsp;<span class="label label-warning">[ [ -∞</span>
+				&nbsp;<span class="label label-warning">∞ ] ]</span>
+		</p>
+		<hr style="border-bottom: dotted 1px #C0C0C0;" />
+		<h3><a name="--italic">--italic </a>
+			 / <small>-</small>
+		</h3>
+		<p class="args">
+			<b>This is a <em>italic</em> <code>String</code> <em>argument</em></b><br />
+			
+		</p>
+		<p>
+			<span class="label label-info ">String</span>
+				&nbsp;<span class="label">""</span>
+		</p>
+
+        <hr>
+        <p><a href='#top'><i class='fa fa-chevron-up'></i> Return to top</a></p>
+        <hr>
+        <p class="version">Barclay version 11.1 built at 2016/01/01 01:01:01.
+        </p>
+
+	</div>
+
+	<?php printFooter($module); ?>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html.json
@@ -1,0 +1,68 @@
+{
+  "summary": "Tool where the documentation is formatted with \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e \u003ccode\u003eString\u003c/code\u003e.",
+  "arguments": [
+    {
+      "summary": "This is a \u003cstrong\u003ebold\u003c/strong\u003e \u003ccode\u003eString\u003c/code\u003e \u003cstrong\u003eargument\u003c/strong\u003e",
+      "name": "--bold",
+      "synonyms": "-",
+      "type": "String",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "\"\"",
+      "minValue": "NA",
+      "maxValue": "NA",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is an \u003ccode\u003edouble\u003c/code\u003e argument with markdown formatted doc",
+      "name": "--DOUBLE",
+      "synonyms": "-",
+      "type": "double",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "0.0",
+      "minValue": "-Infinity",
+      "maxValue": "Infinity",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is an \u003ccode\u003eint\u003c/code\u003e argument with markdown formatted doc",
+      "name": "--INT",
+      "synonyms": "-",
+      "type": "int",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "0",
+      "minValue": "-Infinity",
+      "maxValue": "Infinity",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    },
+    {
+      "summary": "This is a \u003cem\u003eitalic\u003c/em\u003e \u003ccode\u003eString\u003c/code\u003e \u003cem\u003eargument\u003c/em\u003e",
+      "name": "--italic",
+      "synonyms": "-",
+      "type": "String",
+      "required": "no",
+      "fulltext": "",
+      "defaultValue": "\"\"",
+      "minValue": "NA",
+      "maxValue": "NA",
+      "minRecValue": "NA",
+      "maxRecValue": "NA",
+      "kind": "optional",
+      "options": []
+    }
+  ],
+  "description": "\u003cp\u003eDocumentation of this tool is written in Markdown and rendered as HTML.\u003c/p\u003e\n\u003ch2\u003eJavadoc formatted with Markdown\u003c/h2\u003e\n\u003cp\u003eThe purpose of this paragraph is to test embedded \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e formatting:\u003c/p\u003e\n\u003cul\u003e\n\u003cli\u003eFirst element of list (\u003cstrong\u003ebold\u003c/strong\u003e)\u003c/li\u003e\n\u003cli\u003eSecond element of list (\u003cem\u003eitalic\u003c/em\u003e)\u003c/li\u003e\n\u003c/ul\u003e",
+  "name": "ClpWithMarkdownDocs",
+  "group": "markdown"
+}

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html
@@ -6,7 +6,7 @@
 
 	
 
-	<?php $group = 'Test extra docs group name'; ?>
+	<?php $group = 'markdown'; ?>
 
 	<section class="span4">
 		<aside class="well">
@@ -63,22 +63,22 @@
         		<hr>
         </ul>
 		</aside>
-		<?php getForumPosts( 'TestExtraDocs' ) ?>
+		<?php getForumPosts( 'MarkdownDocumentedFeature' ) ?>
 
 	</section>
 
 	<div class="span8">
 
-			<h1>TestExtraDocs **BETA**</h1>
+			<h1>MarkdownDocumentedFeature **BETA**</h1>
 
-		<p class="lead">Class for testing extraDocs property in docgen.</p>
+		<p class="lead">Documented feature formatted with <a href="https://daringfireball.net/projects/markdown/">Markdown</a>.</p>
 
 			<h3>Category
-				<small> Test extra docs group name</small>
+				<small> markdown</small>
 			</h3>
 		<hr>
 		<h2>Overview</h2>
-		Class for testing extraDocs property in docgen.
+		Documentation of this feature is written in Markdown and rendered as HTML.
 
 
 

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html.json
@@ -1,0 +1,6 @@
+{
+  "summary": "Documented feature formatted with \u003ca href\u003d\"https://daringfireball.net/projects/markdown/\"\u003eMarkdown\u003c/a\u003e.",
+  "description": "Documentation of this feature is written in Markdown and rendered as HTML.",
+  "name": "MarkdownDocumentedFeature",
+  "group": "markdown"
+}

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
@@ -27,6 +27,19 @@
         		<hr>
         		<hr>
         		<hr>
+						<li><a data-toggle="collapse" data-parent="#sidenav" href="#markdown">markdown</a>
+							<div id="markdown"
+								<?php echo ($group == 'markdown')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
+								<ul>
+											<li>
+												<a href="org_broadinstitute_barclay_help_ClpWithMarkdownDocs.html">ClpWithMarkdownDocs</a>
+											</li>
+											<li>
+												<a href="org_broadinstitute_barclay_help_MarkdownDocumentedFeature.html">MarkdownDocumentedFeature</a>
+											</li>
+								</ul>
+							</div>
+						</li>
 						<li><a data-toggle="collapse" data-parent="#sidenav" href="#Testextradocsgroupname">Test extra docs group name</a>
 							<div id="Testextradocsgroupname"
 								<?php echo ($group == 'Test extra docs group name')? 'class="accordion-body collapse in"'.chr(62) : 'class="accordion-body collapse"'.chr(62);?>
@@ -65,14 +78,10 @@
 			</h3>
 		<hr>
 		<h2>Overview</h2>
-		Argument container class for testing documentation generation. Contains an argument
- for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should
- be tested.
-
- Test custom tag:
- 
-
- <p>
+		<p>Argument container class for testing documentation generation. Contains an argument
+for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should
+be tested.</p>
+<p>Test custom tag:</p> <p>
  The purpose of this paragraph is to test embedded html formatting.
  <ol>
      <li>This is point number 1</li>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html.json
@@ -335,7 +335,7 @@
       "options": []
     }
   ],
-  "description": "Argument container class for testing documentation generation. Contains an argument\n for each @Argument, @ArgumentCollection, and @DocumentedFeature property that should\n be tested.\n\n Test custom tag:\n \n\n \u003cp\u003e\n The purpose of this paragraph is to test embedded html formatting.\n \u003col\u003e\n     \u003cli\u003eThis is point number 1\u003c/li\u003e\n     \u003cli\u003eThis is point number 2\u003c/li\u003e\n \u003c/ol\u003e\n \u003c/p\u003e",
+  "description": "\u003cp\u003eArgument container class for testing documentation generation. Contains an argument\nfor each @Argument, @ArgumentCollection, and @DocumentedFeature property that should\nbe tested.\u003c/p\u003e\n\u003cp\u003eTest custom tag:\u003c/p\u003e \u003cp\u003e\n The purpose of this paragraph is to test embedded html formatting.\n \u003col\u003e\n     \u003cli\u003eThis is point number 1\u003c/li\u003e\n     \u003cli\u003eThis is point number 2\u003c/li\u003e\n \u003c/ol\u003e\n \u003c/p\u003e",
   "name": "TestArgumentContainer",
   "group": "Test feature group name"
 }


### PR DESCRIPTION
Markdown integration in the CLI help and documentation generation using [commonmark-java](https://github.com/atlassian/commonmark-java). Includes:

- CLI: rendering to plain text fields in argparser annotations
- DocGen: rendering to HTML fields in argparser annotations and javadoc