### PR TITLE
Extract method to allow custom doclet options

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -117,13 +117,16 @@ public class HelpDoclet {
     }
 
     /**
-     * Parse the options for the javadoc command line. The first item is the option name, and the
-     * following the number of items returned by {@link #optionLength(String)} for that option.
+     * Handles javadoc command line options. The first entry in the {@code options} array is the
+     * option name. Subsequent entries contain the option's arguments, the number of which is
+     * determined by the value returned from {@link #optionLength(String)} for that option.
      *
-     * Implementations should override this method and call it to parse the required options.
-     * In addition, to support custom options {@link #optionLength(String)} may be implemented.
+     * <p>Custom Barclay doclets that want to have custom command line options should override this
+     * method, and also provide an implementation of the static method {@link #optionLength}).
+     * Both methods should handle the custom options, and then delegate back to the base class
+     * methods defined here to allow default handling of builtin options.
      *
-     * @param options
+     * @param options Options to parse.
      */
     protected void parseOption(final String[] options) {
         if (options[0].equals(SETTINGS_DIR_OPTION))
@@ -145,11 +148,12 @@ public class HelpDoclet {
     }
 
     /**
-     * Validate the given options against options supported by this doclet.
+     * Validates the given options against options supported by this doclet.
      *
-     * <p>Note: for custom options, doclets should implement a similar static method and call the
-     * one from {@link HelpDoclet} to maintain required options. In addition, custom options should
-     * be handled by {@link #parseOption(String[])}.
+     * <p>Custom Barclay doclets that want to have custom command line options should provide an
+     * implementation of this static method, and also override override {@link #parseOption}).
+     * Both methods should handle the custom options, delegating back to the base class methods
+     * defined here to allow default handling of builtin options.
      *
      * @param option Option to validate.
      * @return Number of potential parameters; 0 if not supported.

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -104,22 +104,7 @@ public class HelpDoclet {
      */
     protected boolean startProcessDocs(final RootDoc rootDoc) throws IOException {
         for (String[] options : rootDoc.options()) {
-            if (options[0].equals(SETTINGS_DIR_OPTION))
-                settingsDir = new File(options[1]);
-            if (options[0].equals(DESTINATION_DIR_OPTION))
-                destinationDir = new File(options[1]);
-            if (options[0].equals(BUILD_TIMESTAMP_OPTION))
-                buildTimestamp = options[1];
-            if (options[0].equals(ABSOLUTE_VERSION_OPTION))
-                absoluteVersion = options[1];
-            if (options[0].equals(INCLUDE_HIDDEN_OPTION))
-                showHiddenFeatures = true;
-            if (options[0].equals(OUTPUT_FILE_EXTENSION_OPTION)) {
-                outputFileExtension = options[1];
-            }
-            if (options[0].equals(INDEX_FILE_EXTENSION_OPTION)) {
-                indexFileExtension = options[1];
-            }
+            parseOption(options);
         }
 
         if (!settingsDir.exists())
@@ -132,7 +117,39 @@ public class HelpDoclet {
     }
 
     /**
+     * Parse the options for the javadoc command line. The first item is the option name, and the
+     * following the number of items returned by {@link #optionLength(String)} for that option.
+     *
+     * Implementations should override this method and call it to parse the required options.
+     * In addition, to support custom options {@link #optionLength(String)} may be implemented.
+     *
+     * @param options
+     */
+    protected void parseOption(final String[] options) {
+        if (options[0].equals(SETTINGS_DIR_OPTION))
+            settingsDir = new File(options[1]);
+        if (options[0].equals(DESTINATION_DIR_OPTION))
+            destinationDir = new File(options[1]);
+        if (options[0].equals(BUILD_TIMESTAMP_OPTION))
+            buildTimestamp = options[1];
+        if (options[0].equals(ABSOLUTE_VERSION_OPTION))
+            absoluteVersion = options[1];
+        if (options[0].equals(INCLUDE_HIDDEN_OPTION))
+            showHiddenFeatures = true;
+        if (options[0].equals(OUTPUT_FILE_EXTENSION_OPTION)) {
+            outputFileExtension = options[1];
+        }
+        if (options[0].equals(INDEX_FILE_EXTENSION_OPTION)) {
+            indexFileExtension = options[1];
+        }
+    }
+
+    /**
      * Validate the given options against options supported by this doclet.
+     *
+     * <p>Note: for custom options, doclets should implement a similar static method and call the
+     * one from {@link HelpDoclet} to maintain required options. In addition, custom options should
+     * be handled by {@link #parseOption(String[])}.
      *
      * @param option Option to validate.
      * @return Number of potential parameters; 0 if not supported.


### PR DESCRIPTION
Very simple patch to allow integrating custom options for a doclet. Currently parsing custom options is a bit painful, but after this change it is as simple as: 

```java
public class CustomDoclet extends HelpDoclet {
    
    ....

    private static final String DEPENDENCY_VERSION_OPTION = "-dependency-version";
    protected static Map<String, String> dependencyVersions = new LinkedHashMap<>();

    @Override
    protected parseOption(Option[] options) {
        super.parseOption(options);
        if (options[0].equals(DEPENDENCY_VERSION_OPTION))
            dependencyVersions.put(options[1], options[2]);
    }

    public static int optionLength(final String option) {
         if (option.equals(DEPENDENCY_VERSION_OPTION)) return 3;
         return HelpDoclet.optionLength(option);
    }

    ....
}
```