### PR TITLE
Several small bugfixes and updates.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/DefaultDocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/barclay/help/DefaultDocWorkUnitHandler.java
@@ -400,6 +400,11 @@ public class DefaultDocWorkUnitHandler extends DocWorkUnitHandler {
                 argBindings.put("minRecValue", "NA");
                 argBindings.put("maxRecValue", "NA");
             }
+
+            // Add in the number of times you can specify it:
+            argBindings.put("minElements", argDef.field.getAnnotation(Argument.class).minElements());
+            argBindings.put("maxElements", argDef.field.getAnnotation(Argument.class).maxElements());
+
             // if its a plugin descriptor arg, get the allowed values
             processPluginDescriptorArgument(argDef, argBindings);
 
@@ -456,6 +461,8 @@ public class DefaultDocWorkUnitHandler extends DocWorkUnitHandler {
             argBindings.put("minValue", "NA");
             argBindings.put("maxValue", "NA");
             argBindings.put("defaultValue", "NA");
+            argBindings.put("minElements", posArgs.minElements());
+            argBindings.put("maxElements", posArgs.maxElements());
 
             args.get("positional").add(argBindings);
             args.get("all").add(argBindings);
@@ -667,8 +674,8 @@ public class DefaultDocWorkUnitHandler extends DocWorkUnitHandler {
      *         synonymous name.
      */
     private Pair<String, String> displayNames(String s1, String s2) {
-        s1 = s1 == null ? null : "-" + s1;
-        s2 = s2 == null ? null : "--" + s2;
+        s1 = ((s1 == null) || (s1.length() == 0)) ? null : "-" + s1;
+        s2 = ((s2 == null) || (s2.length() == 0)) ? null : "--" + s2;
 
         if (s1 == null) return Pair.of(s2, null);
         if (s2 == null) return Pair.of(s1, null);

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -371,7 +371,7 @@ public class HelpDoclet {
      * @param groupMaps
      * @throws IOException
      */
-    private void processIndexTemplate(
+    protected void processIndexTemplate(
             final Configuration cfg,
             final List<DocWorkUnit> workUnitList,
             final List<Map<String, String>> groupMaps

--- a/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.template.html
@@ -31,7 +31,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms??> / <small>${arg.synonyms}</small></#if>
+			<#if arg.synonyms??><#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />

--- a/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.template.html
+++ b/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.template.html
@@ -31,7 +31,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms??><#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if></#if>
+			<#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
@@ -149,7 +149,6 @@
 				</tr>
 				<tr>
 					<td><a href="#--usesFieldNameForArgName">--usesFieldNameForArgName</a><br />
-								&nbsp;<em>-</em>
 					</td>
 					<!--<td>String</td> -->
 					<td>null</td>
@@ -242,7 +241,6 @@
 				</tr>
 				<tr>
 					<td><a href="#--testPlugin">--testPlugin</a><br />
-								&nbsp;<em>-</em>
 					</td>
 					<!--<td>List[String]</td> -->
 					<td>[]</td>
@@ -277,7 +275,7 @@
 					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="[NA - Positional]">[NA - Positional] </a>
-			 / <small>NA</small>
+			
 		</h3>
 		<p class="args">
 			<b>Positional arguments, min = 2, max = 2</b><br />
@@ -538,7 +536,7 @@
 		</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="--testPlugin">--testPlugin </a>
-			 / <small>-</small>
+			
 		</h3>
 		<p class="args">
 			<b>Undocumented option</b><br />
@@ -550,7 +548,7 @@
 		</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="--usesFieldNameForArgName">--usesFieldNameForArgName </a>
-			 / <small>-</small>
+			
 		</h3>
 		<p class="args">
 			<b>Use field name if no name in annotation.</b><br />

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.json
@@ -307,7 +307,7 @@
     {
       "summary": "Undocumented option",
       "name": "--testPlugin",
-      "synonyms": "-",
+      "synonyms": "NA",
       "type": "List[String]",
       "required": "no",
       "fulltext": "",
@@ -322,7 +322,7 @@
     {
       "summary": "Use field name if no name in annotation.",
       "name": "--usesFieldNameForArgName",
-      "synonyms": "-",
+      "synonyms": "NA",
       "type": "String",
       "required": "yes",
       "fulltext": "",

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.html
@@ -161,7 +161,6 @@
 				</tr>
 				<tr>
 					<td><a href="#--usesFieldNameForArgName">--usesFieldNameForArgName</a><br />
-								&nbsp;<em>-</em>
 					</td>
 					<!--<td>String</td> -->
 					<td>null</td>
@@ -254,7 +253,6 @@
 				</tr>
 				<tr>
 					<td><a href="#--testPlugin">--testPlugin</a><br />
-								&nbsp;<em>-</em>
 					</td>
 					<!--<td>List[String]</td> -->
 					<td>[]</td>
@@ -289,7 +287,7 @@
 					<p>Arguments in this list are specific to this tool. Keep in mind that other arguments are available that are shared with other tools (e.g. command-line GATK arguments); see Inherited arguments above.</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="[NA - Positional]">[NA - Positional] </a>
-			 / <small>NA</small>
+			
 		</h3>
 		<p class="args">
 			<b>Positional arguments, min = 2, max = 2</b><br />
@@ -550,7 +548,7 @@
 		</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="--testPlugin">--testPlugin </a>
-			 / <small>-</small>
+			
 		</h3>
 		<p class="args">
 			<b>Undocumented option</b><br />
@@ -562,7 +560,7 @@
 		</p>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="--usesFieldNameForArgName">--usesFieldNameForArgName </a>
-			 / <small>-</small>
+			
 		</h3>
 		<p class="args">
 			<b>Use field name if no name in annotation.</b><br />

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.json
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/TestDoclet/org_broadinstitute_barclay_help_TestArgumentContainer.json
@@ -307,7 +307,7 @@
     {
       "summary": "Undocumented option",
       "name": "--testPlugin",
-      "synonyms": "-",
+      "synonyms": "NA",
       "type": "List[String]",
       "required": "no",
       "fulltext": "",
@@ -322,7 +322,7 @@
     {
       "summary": "Use field name if no name in annotation.",
       "name": "--usesFieldNameForArgName",
-      "synonyms": "-",
+      "synonyms": "NA",
       "type": "String",
       "required": "yes",
       "fulltext": "",

--- a/src/test/resources/org/broadinstitute/barclay/help/templates/TestDoclet/generic.template.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/templates/TestDoclet/generic.template.html
@@ -31,7 +31,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms??> / <small>${arg.synonyms}</small></#if>
+			<#if arg.synonyms??><#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />

--- a/src/test/resources/org/broadinstitute/barclay/help/templates/TestDoclet/generic.template.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/templates/TestDoclet/generic.template.html
@@ -31,7 +31,7 @@
 	<#macro argumentDetails arg>
 		<hr style="border-bottom: dotted 1px #C0C0C0;" />
 		<h3><a name="${arg.name}">${arg.name} </a>
-			<#if arg.synonyms??><#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if></#if>
+			<#if arg.synonyms != "NA"> / <small>${arg.synonyms}</small></#if>
 		</h3>
 		<p class="args">
 			<b>${arg.summary}</b><br />


### PR DESCRIPTION
Pulled out some small changes in a larger  PR ( #82 )  into this one for ease of merging.

Added minElements and maxElements to freemarker objects (they were
    present in the data, but not being pushed into freemarker).

Fixed display names not to show up with '-' as values when they are
empty or null.

ProcessIndexTemplate is now protected.

In the default templates, arguments that have no synonyms no longer
render synonyms at all (as opposed to showing up as NA).