### PR TITLE
Fixed a bug in pulling templates from the classpath.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -380,11 +380,14 @@ public class HelpDoclet {
             // We need to set up a scheme to load our settings from wherever they may live.
             // This means we need to set up a multi-loader including the classpath and any specified options:
 
-            TemplateLoader templateLoader =  new FileTemplateLoader(new File(settingsDir.getPath()));
+            TemplateLoader templateLoader;
 
             // Only add the settings directory if we're supposed to:
             if ( useDefaultTemplates ) {
                 templateLoader = new ClassTemplateLoader(getClass(), DEFAULT_SETTINGS_CLASSPATH);
+            }
+            else {
+                templateLoader = new FileTemplateLoader(new File(settingsDir.getPath()));
             }
 
             // Tell freemarker to load our templates as we specified above:


### PR DESCRIPTION
Fixes an issue when creating a tab-completion file and using the default templates.

Before the code was erroneously trying to read a file for the template whether or not the user specified using the default template.  This caused a FileNotFoundException when that path did not exist even when using the default template.

Now the code correctly splits creating the template object into two cases - the default template and a user-defined template.