### PR TITLE
Legacy parser should throw on optional List argument if not provided.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
@@ -423,13 +423,16 @@ public class LegacyCommandLineArgumentParser implements CommandLineParser {
                 }
                 if (optionDefinition.isCollection) {
                     final Collection<?> c = (Collection<?>) optionDefinition.field.get(optionDefinition.parent);
+                    if (c.size() == 0 && !optionDefinition.optional) {
+                        messageStream.print("ERROR: Option '" + fullName + "' is required");
+                        return false;
+                    }
                     if (c.size() < optionDefinition.minElements) {
                         messageStream.println("ERROR: Option '" + fullName + "' must be specified at least " +
                                 optionDefinition.minElements + " times.");
                         return false;
                     }
-                } else if (!optionDefinition.optional && !optionDefinition.hasBeenSet &&
-                        !optionDefinition.hasBeenSetFromParent && mutextOptionNames.length() == 0) {
+                } else if (!optionDefinition.optional && !optionDefinition.hasBeenSet && mutextOptionNames.length() == 0) {
                     messageStream.print("ERROR: Option '" + fullName + "' is required");
                     if (optionDefinition.mutuallyExclusive.isEmpty()) {
                         messageStream.println(".");
@@ -968,7 +971,6 @@ public class LegacyCommandLineArgumentParser implements CommandLineParser {
         final boolean isCommon;
         boolean hasBeenSet = false;
         boolean hasBeenSetFromOptionsFile = false;
-        boolean hasBeenSetFromParent = false;
         final Set<String> mutuallyExclusive;
 
         private OptionDefinition(final Field field, final Object parent,final String name, final String shortName, final String doc,

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
@@ -211,6 +211,37 @@ public final class CommandLineArgumentParserTest {
         validateRequiredOptionalUsage(clp, false, false); // without common args
     }
 
+    class CollectionThatCannotBeAutoInitializedOptions {
+        // the command line parser will instantiate a collection object for a collection argument
+        // if its type is instantiable, or if its type is compatible with List, but not for any other type of
+        // collection (such as a Set)
+        @Argument(optional=false)
+        public Set<File> SET;
+    }
+
+    @Test(expectedExceptions = CommandLineException.CommandLineParserInternalException.class)
+    public void testCollectionThatCANNOTBeAutoInitialized() {
+        final CollectionThatCannotBeAutoInitializedOptions o = new CollectionThatCannotBeAutoInitializedOptions();
+        new CommandLineArgumentParser(o);
+        Assert.fail("Exception should have been thrown");
+    }
+
+    class CollectionThatCanBeAutoInitializedOptions {
+        // the command line parser will instantiate a collection object for a collection argument
+        // if its type is instantiable, or if its type is compatible with List, but not for any other type of
+        // collection (such as a Set)
+        @Argument(optional=false)
+        public List<File> LIST;
+    }
+
+    @Test(expectedExceptions = CommandLineException.MissingArgument.class)
+    public void testListThatCANBeAutoInitialized() {
+        // Although the list will be auto-initialized, the argument is required but not provided, so parseArgs will fail
+        final CollectionThatCanBeAutoInitializedOptions o = new CollectionThatCanBeAutoInitializedOptions();
+        final CommandLineArgumentParser clp = new CommandLineArgumentParser(o);
+        Assert.assertNotEquals(clp.parseArguments(System.err, new String[]{}), 0, "Should fail due to missing Argument");
+    }
+
     @Test
     public void testPositive() {
         final String[] args = {

--- a/src/test/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParserTest.java
@@ -564,16 +564,35 @@ public class LegacyCommandLineArgumentParserTest {
         Assert.assertEquals(o.COLLECTION.size(), 2);
     }
 
-    class UninitializedCollectionThatCannotBeAutoInitializedOptions {
-        @Argument
-        public Set<String> SET;
+    class CollectionThatCannotBeAutoInitializedOptions {
+        @Argument(optional=false)
+        public Set<File> SET;
     }
 
     @Test(expectedExceptions = CommandLineException.CommandLineParserInternalException.class)
     public void testCollectionThatCannotBeAutoInitialized() {
-        final UninitializedCollectionThatCannotBeAutoInitializedOptions o = new UninitializedCollectionThatCannotBeAutoInitializedOptions();
+        // the legacy command line parser will instantiate a collection object for a collection argument
+        // if its type is instantiable, or if its type is compatible with List, but not for any other type of
+        // collection (such as a Set)
+        final CollectionThatCannotBeAutoInitializedOptions o = new CollectionThatCannotBeAutoInitializedOptions();
         new LegacyCommandLineArgumentParser(o);
         Assert.fail("Exception should have been thrown");
+    }
+
+    class CollectionThatCanBeAutoInitializedOptions {
+        // the legacy command line parser will instantiate a collection object for a collection argument
+        // if its type is instantiable, or if its type is compatible with List, but not for any other type of
+        // collection (such as a Set)
+        @Argument(optional=false)
+        public List<File> list;
+    }
+
+    @Test
+    public void testListThatCanBeAutoInitialized() {
+        // Although the list will be auto-initialized, the argument is required but not provided, so parseArgs will fail
+        final CollectionThatCanBeAutoInitializedOptions o = new CollectionThatCanBeAutoInitializedOptions();
+        final LegacyCommandLineArgumentParser clp = new LegacyCommandLineArgumentParser(o);
+        Assert.assertNotEquals(clp.parseArguments(System.err, new String[]{}), 0, "Should fail due to missing Argument");
     }
 
     class CollectionWithDefaultValuesOptions {


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/picard/issues/950.