### PR TITLE
Fix word wrapping in the argument description. 

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -1,13 +1,7 @@
 package org.broadinstitute.barclay.argparser;
 
-import joptsimple.OptionException;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
-import joptsimple.OptionSpecBuilder;
+import joptsimple.*;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -790,7 +790,7 @@ public final class CommandLineArgumentParser implements CommandLineParser {
             numSpaces = ARGUMENT_COLUMN_WIDTH;
         }
         printSpaces(sb, numSpaces);
-        final String wrappedDescription = WordUtils.wrap(argumentDescription, DESCRIPTION_COLUMN_WIDTH);
+        final String wrappedDescription = Utils.wrapParagraph(argumentDescription, DESCRIPTION_COLUMN_WIDTH);
         final String[] descriptionLines = wrappedDescription.split("\n");
         for (int i = 0; i < descriptionLines.length; ++i) {
             if (i > 0) {

--- a/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/LegacyCommandLineArgumentParser.java
@@ -26,6 +26,7 @@ package org.broadinstitute.barclay.argparser;
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.broadinstitute.barclay.utils.Utils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -649,7 +650,7 @@ public class LegacyCommandLineArgumentParser implements CommandLineParser {
         }
         printSpaces(sb, numSpaces);
         checkForNonASCII(optionDescription, name);
-        final String wrappedDescription = WordUtils.wrap(convertFromHtml(optionDescription), DESCRIPTION_COLUMN_WIDTH);
+        final String wrappedDescription = Utils.wrapParagraph(convertFromHtml(optionDescription), DESCRIPTION_COLUMN_WIDTH);
         final String[] descriptionLines = wrappedDescription.split("\n");
         for (int i = 0; i < descriptionLines.length; ++i) {
             if (i > 0) {

--- a/src/main/java/org/broadinstitute/barclay/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/barclay/utils/Utils.java
@@ -141,6 +141,15 @@ public class Utils {
         return lhs == null && rhs == null || lhs != null && lhs.equals(rhs);
     }
 
+    /**
+     * a utility method to wrap multiple lines of text, while respecting the original
+     * newlines.
+     *
+     * @param input the String of text to wrap
+     * @param width the width in characters into which to wrap the text
+     * @return the original string with newlines added, and starting spaces trimmed
+     * so that the resulting lines fit inside a column of with characters.
+     */
     public static String wrapParagraph(final String input, final int width)  {
         final StringBuilder out = new StringBuilder();
         String line;
@@ -153,7 +162,10 @@ public class Utils {
             throw new RuntimeException(e);
         }
 
-        if (!input.substring(input.length()-1).equals("\n")) out.delete(out.length() - 1, out.length());
+        //unless the original string ends in a newline, we need to remove the last newline that was added.
+        if (input.length() > 0 && !input.substring(input.length()-1).equals("\n")){
+            out.delete(out.length() - 1, out.length());
+        }
         return out.toString();
     }
 }

--- a/src/main/java/org/broadinstitute/barclay/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/barclay/utils/Utils.java
@@ -1,5 +1,10 @@
 package org.broadinstitute.barclay.utils;
 
+import org.apache.commons.lang3.text.WordUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -136,4 +141,19 @@ public class Utils {
         return lhs == null && rhs == null || lhs != null && lhs.equals(rhs);
     }
 
+    public static String wrapParagraph(final String input, final int width)  {
+        final StringBuilder out = new StringBuilder();
+        String line;
+        try(final BufferedReader bufReader = new BufferedReader(new StringReader(input))) {
+            while ((line = bufReader.readLine()) != null) {
+                out.append(WordUtils.wrap(line, width));
+                out.append("\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!input.substring(input.length()-1).equals("\n")) out.delete(out.length() - 1, out.length());
+        return out.toString();
+    }
 }

--- a/src/main/java/org/broadinstitute/barclay/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/barclay/utils/Utils.java
@@ -142,29 +142,33 @@ public class Utils {
     }
 
     /**
-     * a utility method to wrap multiple lines of text, while respecting the original
+     * A utility method to wrap multiple lines of text, while respecting the original
      * newlines.
      *
      * @param input the String of text to wrap
-     * @param width the width in characters into which to wrap the text
+     * @param width the width in characters into which to wrap the text. Less than 1 is treated as 1
      * @return the original string with newlines added, and starting spaces trimmed
      * so that the resulting lines fit inside a column of with characters.
      */
-    public static String wrapParagraph(final String input, final int width)  {
+    public static String wrapParagraph(final String input, final int width) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
         final StringBuilder out = new StringBuilder();
         String line;
-        try(final BufferedReader bufReader = new BufferedReader(new StringReader(input))) {
+        try (final BufferedReader bufReader = new BufferedReader(new StringReader(input))) {
             while ((line = bufReader.readLine()) != null) {
                 out.append(WordUtils.wrap(line, width));
                 out.append("\n");
             }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Unreachable Statement.\nHow did the Buffered reader throw when it was " +
+                    "wrapping a StringReader?", e);
         }
 
         //unless the original string ends in a newline, we need to remove the last newline that was added.
-        if (input.length() > 0 && !input.substring(input.length()-1).equals("\n")){
-            out.delete(out.length() - 1, out.length());
+        if (input.charAt(input.length() - 1) != '\n') {
+            out.deleteCharAt(out.length() - 1);
         }
         return out.toString();
     }

--- a/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
@@ -4,10 +4,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-
-import static java.util.Arrays.asList;
-
 public class UtilsUnitTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -45,14 +41,17 @@ public class UtilsUnitTest {
                 {"hello \nhello hello hello hello", "hello \nhello hello hello\nhello", 20},
                 {"hello \nhello hello hello hello\n", "hello \nhello hello hello\nhello\n", 20},
                 {"hello \nhello hello hello hello\n\n", "hello \nhello hello hello\nhello\n\n", 20},
+                {"", "", 20},
+                {" ", "", 20},
+                {"\n", "\n", 20},
+
         };
 
     }
 
     @Test(dataProvider = "testWrapParagraphData")
-    void testWrapParagraph( final String input, final String expectedOutput, final int width) {
-
-        Assert.assertEquals(Utils.wrapParagraph(input,width),expectedOutput);
+    void testWrapParagraph(final String input, final String expectedOutput, final int width) {
+        Assert.assertEquals(Utils.wrapParagraph(input, width), expectedOutput);
     }
 
 }

--- a/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.barclay.utils;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
 
 import static java.util.Arrays.asList;
 
@@ -28,6 +31,28 @@ public class UtilsUnitTest {
     public void testNonNullWithMessageReturn() {
         final Object testObject = new Object();
         Assert.assertSame(Utils.nonNull(testObject, "some message"), testObject);
+    }
+
+
+    @DataProvider
+    public Object[][] testWrapParagraphData(){
+        return new Object[][]{
+                {"hello \nhello hello hello hello", "hello \nhello hello\nhello hello", 12},
+                {"hello \nhello hello hello hello", "hello \nhello hello\nhello hello", 11},
+                {"hello \nhello hello hello hello", "hello \nhello\nhello\nhello\nhello", 10},
+                {"hello \n\n\n\nhello hello hello hello", "hello \n\n\n\nhello\nhello\nhello\nhello", 10},
+
+                {"hello \nhello hello hello hello", "hello \nhello hello hello\nhello", 20},
+                {"hello \nhello hello hello hello\n", "hello \nhello hello hello\nhello\n", 20},
+                {"hello \nhello hello hello hello\n\n", "hello \nhello hello hello\nhello\n\n", 20},
+        };
+
+    }
+
+    @Test(dataProvider = "testWrapParagraphData")
+    void testWrapParagraph( final String input, final String expectedOutput, final int width) {
+
+        Assert.assertEquals(Utils.wrapParagraph(input,width),expectedOutput);
     }
 
 }

--- a/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
@@ -29,7 +29,6 @@ public class UtilsUnitTest {
         Assert.assertSame(Utils.nonNull(testObject, "some message"), testObject);
     }
 
-
     @DataProvider
     public Object[][] testWrapParagraphData(){
         return new Object[][]{
@@ -41,26 +40,23 @@ public class UtilsUnitTest {
                 {"hello \nhello hello hello hello", "hello \nhello hello hello\nhello", 20},
                 {"hello \nhello hello hello hello\n", "hello \nhello hello hello\nhello\n", 20},
                 {"hello \nhello hello hello hello\n\n", "hello \nhello hello hello\nhello\n\n", 20},
+
                 {"", "", 20},
                 {" ", "", 20},
                 {"\n", "\n", 20},
                 {null, null, 20},
+
                 {"hello","hello",0},
                 {"hello","hello",-1},
                 {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",1},
                 {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",0},
                 {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",-1},
-                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",-1000},
-
-
+                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",-1000}
         };
-
     }
 
     @Test(dataProvider = "testWrapParagraphData")
     void testWrapParagraph(final String input, final String expectedOutput, final int width) {
         Assert.assertEquals(Utils.wrapParagraph(input, width), expectedOutput);
     }
-
-
 }

--- a/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/utils/UtilsUnitTest.java
@@ -44,6 +44,14 @@ public class UtilsUnitTest {
                 {"", "", 20},
                 {" ", "", 20},
                 {"\n", "\n", 20},
+                {null, null, 20},
+                {"hello","hello",0},
+                {"hello","hello",-1},
+                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",1},
+                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",0},
+                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",-1},
+                {"a b c d e f g","a\nb\nc\nd\ne\nf\ng",-1000},
+
 
         };
 
@@ -53,5 +61,6 @@ public class UtilsUnitTest {
     void testWrapParagraph(final String input, final String expectedOutput, final int width) {
         Assert.assertEquals(Utils.wrapParagraph(input, width), expectedOutput);
     }
+
 
 }


### PR DESCRIPTION
The wordWrap functionality used here is designed to wrap a single line, but was used on a paragraphs. this leads to poor-looking descriptions of the arguments in the help-docs. 

This PR fixes that.