### PR TITLE
Change the default args list expansion extension to .args.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -57,7 +57,7 @@ public final class CommandLineArgumentParser implements CommandLineParser {
     public static final String POSITIONAL_ARGUMENTS_NAME = "Positional Argument";
 
     // Extension for collection argument list files
-    private static final String COLLECTION_LIST_FILE_EXTENSION = ".list";
+    static final String COLLECTION_LIST_FILE_EXTENSION = ".args";
 
     private static final Logger logger = LogManager.getLogger();
 

--- a/src/test/java/org/broadinstitute/barclay/argparser/CollectionArgumentUnitTests.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CollectionArgumentUnitTests.java
@@ -281,7 +281,7 @@ public class CollectionArgumentUnitTests {
     // Helper methods
 
     private File createListArgumentFile(final String fileName, final String[] argList) throws IOException {
-        final File listFile = File.createTempFile(fileName, ".list");
+        final File listFile = File.createTempFile(fileName, CommandLineArgumentParser.COLLECTION_LIST_FILE_EXTENSION);
         listFile.deleteOnExit();
         try (final PrintWriter writer = new PrintWriter(listFile)) {
             Arrays.stream(argList).forEach(arg -> writer.println(arg));


### PR DESCRIPTION
Change the default extension for auto-expansion of command line args to ".args" from ".list", which was causing problems with Picard interval lists. Fixes https://github.com/broadinstitute/barclay/issues/94.

This is a short term fix. The longer term fix is in https://github.com/broadinstitute/barclay/pull/95.
