### PR TITLE
Changed argument parser to handle argument collections on PluginDescriptors

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -842,19 +842,19 @@ public final class CommandLineArgumentParser implements CommandLineParser {
     private void usageForPluginDescriptorArgumentIfApplicable(final ArgumentDefinition argDef, final StringBuilder sb) {
         if (CommandLineParser.getUnderlyingType(argDef.field).equals(String.class)) {
             for (CommandLinePluginDescriptor<?> descriptor : pluginDescriptors.values()) {
-                // this argument came from a plugin descriptor; delegate to get the list of allowed values
+                // See if this this argument came from a plugin descriptor; delegate to get the list of allowed values if it is
                 final Set<String> allowedValues = descriptor.getAllowedValuesForDescriptorArgument(argDef.getLongName());
-                if (allowedValues == null) {
-                    // Do nothing because the argument doesn't belong to this descriptor
-                } else if (allowedValues.isEmpty()) {
-                    sb.append("Any value allowed");
-                    return;
-                } else {
-                    sb.append("Possible Values: {");
-                    sb.append(String.join(", ", allowedValues.stream().sorted(String::compareToIgnoreCase).collect(Collectors.toList())));
-                    sb.append("}");
+                if (allowedValues != null) {
+                    if (allowedValues.isEmpty()) {
+                        sb.append("Any value allowed");
+                    } else {
+                        sb.append("Possible Values: {");
+                        sb.append(String.join(", ", allowedValues.stream().sorted(String::compareToIgnoreCase).collect(Collectors.toList())));
+                        sb.append("}");
+                    }
                     return;
                 }
+                // Do nothing because the argument doesn't belong to this descriptor
             }
         }
         // If the argument wasn't claimed by any descriptor, treat it as a normal argument

--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -817,15 +817,10 @@ public final class CommandLineArgumentParser implements CommandLineParser {
         } else {
             sb.append("Required. ");
         }
-        // if this argument definition is a string field contained within a plugin descriptor (i.e.,
+        // if this argument definition is a string field claimed by a plugin descriptor (i.e.,
         // it holds the names of plugins specified by the user on the command line, such as read filter names),
         // then we need to delegate to the plugin descriptor to generate the list of allowed values
-        if (CommandLinePluginDescriptor.class.isAssignableFrom(argumentDefinition.parent.getClass()) &&
-                CommandLineParser.getUnderlyingType(argumentDefinition.field).equals(String.class)) {
-            usageForPluginDescriptorArgument(argumentDefinition, sb);
-        } else {
-            sb.append(getOptions(CommandLineParser.getUnderlyingType(argumentDefinition.field)));
-        }
+        usageForPluginDescriptorArgumentIfApplicable(argumentDefinition, sb);
         if (!argumentDefinition.mutuallyExclusive.isEmpty()) {
             sb.append(" Cannot be used in conjuction with argument(s)");
             for (final String argument : argumentDefinition.mutuallyExclusive) {
@@ -844,18 +839,26 @@ public final class CommandLineArgumentParser implements CommandLineParser {
         return sb.toString();
     }
 
-    private void usageForPluginDescriptorArgument(final ArgumentDefinition argDef, final StringBuilder sb) {
-        final CommandLinePluginDescriptor<?> descriptor = (CommandLinePluginDescriptor<?>) argDef.parent;
-        // this argument came from a plugin descriptor; delegate to get the list of allowed values
-        final List<String> allowedValues = new ArrayList<>(descriptor.getAllowedValuesForDescriptorArgument(argDef.getLongName()));
-        if (allowedValues.isEmpty()) {
-            sb.append("Any value allowed");
-        } else {
-            allowedValues.sort(String.CASE_INSENSITIVE_ORDER);
-            sb.append("Possible Values: {");
-            sb.append(String.join(", ", allowedValues));
-            sb.append("}");
+    private void usageForPluginDescriptorArgumentIfApplicable(final ArgumentDefinition argDef, final StringBuilder sb) {
+        if (CommandLineParser.getUnderlyingType(argDef.field).equals(String.class)) {
+            for (CommandLinePluginDescriptor<?> descriptor : pluginDescriptors.values()) {
+                // this argument came from a plugin descriptor; delegate to get the list of allowed values
+                final Set<String> allowedValues = descriptor.getAllowedValuesForDescriptorArgument(argDef.getLongName());
+                if (allowedValues == null) {
+                    // Do nothing because the argument doesn't belong to this descriptor
+                } else if (allowedValues.isEmpty()) {
+                    sb.append("Any value allowed");
+                    return;
+                } else {
+                    sb.append("Possible Values: {");
+                    sb.append(String.join(", ", allowedValues.stream().sorted(String::compareToIgnoreCase).collect(Collectors.toList())));
+                    sb.append("}");
+                    return;
+                }
+            }
         }
+        // If the argument wasn't claimed by any descriptor, treat it as a normal argument
+        sb.append(getOptions(CommandLineParser.getUnderlyingType(argDef.field)));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLinePluginDescriptor.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLinePluginDescriptor.java
@@ -108,11 +108,12 @@ public abstract class CommandLinePluginDescriptor<T> {
     /**
      * Return the allowable values for the String argument of this plugin descriptor
      * that is specified by longArgName. Called by the command line parser to generate
-     * a usage string. If the value is unrecognized, the implementation should throw
-     * IllegalArgumentException.
+     * a usage string. If the value is unrecognized, the implementation should return
+     * null.
      *
      * @param longArgName
-     * @return Set<String> of allowable values, or empty set if any value is allowed
+     * @return Set<String> of allowable values, empty set if any value is allowed,
+     *         or null if the argument doesn't belong to the descriptor
      */
     public abstract Set<String> getAllowedValuesForDescriptorArgument(String longArgName);
 

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLinePluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLinePluginUnitTest.java
@@ -44,6 +44,11 @@ public class CommandLinePluginUnitTest {
         Integer argumentForDefaultTestPlugin;
     }
 
+    public static class TestDefaultPluginArgumentCollection {
+        @Argument(fullName = TestPluginDescriptor.testPluginArgumentName, optional=true)
+        public final List<String> userPluginNames = new ArrayList<>(); // preserve order
+    }
+
     public static class TestPluginDescriptor extends CommandLinePluginDescriptor<TestPluginBase> {
 
         private static final String pluginPackageName = "org.broadinstitute.barclay.argparser";
@@ -51,8 +56,8 @@ public class CommandLinePluginUnitTest {
 
         public static final String testPluginArgumentName = "testPlugin";
 
-        @Argument(fullName = testPluginArgumentName, optional=true)
-        public final List<String> userPluginNames = new ArrayList<>(); // preserve order
+        @ArgumentCollection
+        public final TestDefaultPluginArgumentCollection collection = new TestDefaultPluginArgumentCollection(); // preserve order
 
         private List<TestPluginBase> defaultPlugins = new ArrayList<>();
 
@@ -123,7 +128,7 @@ public class CommandLinePluginUnitTest {
             // make sure the predecessor for this dependent class was either specified
             // on the command line or is a tool default, otherwise reject it
             String predecessorName = dependentClass.getSimpleName();
-            boolean isAllowed = userPluginNames.contains(predecessorName);
+            boolean isAllowed = collection.userPluginNames.contains(predecessorName);
             if (isAllowed) {
                 // keep track of the ones we allow so we can validate later that they
                 // weren't subsequently disabled
@@ -151,8 +156,8 @@ public class CommandLinePluginUnitTest {
         public List<TestPluginBase> getAllInstances() {
             // Add the instances in the order they were specified on the command line
             //
-            final ArrayList<TestPluginBase> filters = new ArrayList<>(userPluginNames.size());
-            userPluginNames.forEach(s -> filters.add(testPlugins.get(s)));
+            final ArrayList<TestPluginBase> filters = new ArrayList<>(collection.userPluginNames.size());
+            collection.userPluginNames.forEach(s -> filters.add(testPlugins.get(s)));
             return filters;
         }
 
@@ -164,8 +169,7 @@ public class CommandLinePluginUnitTest {
             if (longArgName.equals(testPluginArgumentName)) {
                 return testPlugins.keySet();
             }
-            throw new IllegalArgumentException("Allowed values request for unrecognized string argument: " + longArgName);
-        }
+            return null; }
 
         /**
          * Validate the list of arguments and reduce the list of plugins to those
@@ -175,7 +179,7 @@ public class CommandLinePluginUnitTest {
         @Override
         public void validateArguments() {
             Set<String> seenNames = new HashSet<>();
-            seenNames.addAll(userPluginNames);
+            seenNames.addAll(collection.userPluginNames);
 
             Set<String> validNames = new HashSet<>();
             validNames.add(org.broadinstitute.barclay.argparser.CommandLinePluginUnitTest.TestPluginWithRequiredArg.class.getSimpleName());
@@ -185,7 +189,7 @@ public class CommandLinePluginUnitTest {
             if (seenNames.retainAll(validNames)) {
                 throw new CommandLineException.BadArgumentValue("Illegal command line plugin specified");
             }
-            userPluginNames.retainAll(seenNames);
+            collection.userPluginNames.retainAll(seenNames);
         }
 
     }
@@ -400,8 +404,7 @@ public class CommandLinePluginUnitTest {
             if (longArgName.equals(collisionPluginArgName) ){
                 return pluginInstances.keySet();
             }
-            throw new IllegalArgumentException("Allowed values request for unrecognized string argument: " + longArgName);
-
+            return null;
         }
         @Override
         public boolean isDependentArgumentAllowed(Class<?> targetPluginClass) {

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLinePluginUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLinePluginUnitTest.java
@@ -169,7 +169,8 @@ public class CommandLinePluginUnitTest {
             if (longArgName.equals(testPluginArgumentName)) {
                 return testPlugins.keySet();
             }
-            return null; }
+            return null;
+        }
 
         /**
          * Validate the list of arguments and reduce the list of plugins to those


### PR DESCRIPTION
I accomplished this by making the PluginDescriptor responsible for knowing which arguments belong to it and passing every argument to the descriptor. 

Fixes #121