### PR TITLE
*Disable jopt argument clustering.

### DIFF
--- a/src/main/java/joptsimple/BarclayOptionParser.java
+++ b/src/main/java/joptsimple/BarclayOptionParser.java
@@ -1,0 +1,32 @@
+package joptsimple;
+
+import joptsimple.util.KeyValuePair;
+
+/**
+ * Custom subclass of the jopt parser for Barclay. Overrides short argument handling
+ * so that short arg clustering is disabled.
+ */
+public class BarclayOptionParser extends OptionParser {
+    public BarclayOptionParser(final boolean allowAbbreviations) {
+        super(allowAbbreviations);
+    }
+
+    /**
+     * Only delegate short arg handling to the base class if we're guaranteed that the option will be
+     * recognized using the full argument string. Otherwise the base class implementation will fall back
+     * to clustered short name recognition, which we want to disable to avoid the confusing error message
+     * generated.
+     */
+    @Override
+    void handleShortOptionToken( String candidate, ArgumentList arguments, OptionSet detected ) {
+        KeyValuePair optionAndArgument = KeyValuePair.valueOf( candidate.substring( 1 ) );
+
+        if ( isRecognized( optionAndArgument.key ) ) {
+            super.handleShortOptionToken(candidate, arguments, detected );
+        }
+        else {
+            throw new UnrecognizedOptionException(candidate);
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParser.java
@@ -527,7 +527,7 @@ public final class CommandLineArgumentParser implements CommandLineParser {
     }
 
     private OptionParser getOptionParser() {
-        final OptionParser parser = new OptionParser(false);
+        final OptionParser parser = new BarclayOptionParser(false);
         for (final NamedArgumentDefinition argDef : namedArgumentDefinitions){
             final OptionSpecBuilder bld = parser.acceptsAll(argDef.getArgumentAliases(), argDef.getDocString());
             if (argDef.isFlag()) {

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
@@ -189,6 +189,19 @@ public final class CommandLineArgumentParserTest {
         clp.parseArguments(System.err, new String[]{"--" + AbbreviatableArgument.ARGUMENT_NAME.substring(0,5)});
     }
 
+    @Test
+    public void testEnsureClusteringDisabled() {
+        final String clusterOfShortArgs = "-cluster";
+        final CommandLineArgumentParser clp = new CommandLineArgumentParser(new Object());
+        final CommandLineException e = Assert.expectThrows(
+                CommandLineException.class,
+                () -> clp.parseArguments(System.err, new String[]{clusterOfShortArgs}));
+        // If clustering is enabled, the string "cluster" would be interpreted as a series of short arg names, the
+        // first one being "c", so the error message will say "-c is not...", but we want to ensure it says
+        // "-cluster is not..."
+        Assert.assertTrue(e.getMessage().startsWith(clusterOfShortArgs));
+    }
+
     @CommandLineProgramProperties(
             summary = "[oscillation_frequency]\n\nRecalibrates overthruster oscillation. \n",
             oneLineSummary = "Recalibrates the overthruster.",


### PR DESCRIPTION
I don't see any sanctioned way to do this; the code in this PR works by inserting a class into the jopt package namespace to allow a custom subclass of the parser.