### PR TITLE
Ability to construct a file from a URI

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
@@ -278,7 +278,9 @@ public abstract class ArgumentDefinition {
      */
     public static File fileFromFileSchemeURI(final String uri) {
         if (uri == null) throw new IllegalArgumentException("File URI cannot be null");
-        return new File(URI.create(uri));
+        // compensate for applications that don't correctly endode # and ? which may never legally appear in a URI
+        String tolerantUri = uri.replace("#", "%23").replace("?", "%3F");
+        return new File(URI.create(tolerantUri));
     }
 
     /**

--- a/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
@@ -2,8 +2,10 @@ package org.broadinstitute.barclay.argparser;
 
 import org.broadinstitute.barclay.utils.Utils;
 
+import java.io.File;
 import java.io.PrintStream;
 import java.lang.reflect.*;
+import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -238,6 +240,13 @@ public abstract class ArgumentDefinition {
                                     getEnumOptions(clazz)));
                 }
             }
+
+            // Some programs like Cromwell will accept URI paths to files but others expect a File (which can be made
+            // from a URI) so if a File is expected and the String begins with the file scheme return a file from the URI
+            if(clazz.equals(File.class) && stringValue.startsWith("file://")){
+                return new File(URI.create(stringValue));
+            }
+
             // Need to use getDeclaredConstructor() instead of getConstructor() in case the constructor
             // is non-public. Set it to be accessible if it isn't already.
             final Constructor<?> ctor = clazz.getDeclaredConstructor(String.class);

--- a/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/ArgumentDefinition.java
@@ -244,7 +244,7 @@ public abstract class ArgumentDefinition {
             // Some programs like Cromwell will accept URI paths to files but others expect a File (which can be made
             // from a URI) so if a File is expected and the String begins with the file scheme return a file from the URI
             if(clazz.equals(File.class) && stringValue.startsWith("file://")){
-                return new File(URI.create(stringValue));
+                return fileFromFileSchemeURI(stringValue);
             }
 
             // Need to use getDeclaredConstructor() instead of getConstructor() in case the constructor
@@ -268,6 +268,17 @@ public abstract class ArgumentDefinition {
                     stringValue,
                     String.format("Failure constructing '%s' from the string '%s'.", clazz.getSimpleName(), stringValue));
         }
+    }
+
+    /**
+     * Construct a File from a String in the form of a file scheme URI ("file:///some/file")
+     * Equivalent of: <code>File(URI.create(uri))</code>
+     * @param uri the file URI
+     * @return a File representing the URI
+     */
+    public static File fileFromFileSchemeURI(final String uri) {
+        if (uri == null) throw new IllegalArgumentException("File URI cannot be null");
+        return new File(URI.create(uri));
     }
 
     /**

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -4,7 +4,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +62,11 @@ public class NamedArgumentDefinitionUnitTest {
                 // NOTE: non-intuitive case: it looks like its required but isn't since it has a value
                 { new Object() { @Argument(optional=false) List<String> arg = Arrays.asList(new String[] { "stuff", "more stuff" }); },
                         "arg", true, "[stuff, more stuff]" },
+
+                { new Object(){ @Argument(optional = false) File arg; }, "arg", false, NamedArgumentDefinition.NULL_ARGUMENT_STRING},
+                { new Object(){ @Argument(optional = true) File arg = new File("/some/file"); }, "arg", true, "/some/file"},
+                { new Object(){ @Argument(optional = true) File arg = new File(URI.create("file://some/file")); }, "arg", true, "/some/file"},
+
         };
     }
 

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -65,7 +65,11 @@ public class NamedArgumentDefinitionUnitTest {
 
                 { new Object(){ @Argument(optional = false) File arg; }, "arg", false, NamedArgumentDefinition.NULL_ARGUMENT_STRING},
                 { new Object(){ @Argument(optional = true) File arg = new File("/some/file"); }, "arg", true, "/some/file"},
+                { new Object(){ @Argument(optional = true) List<File> arg = Arrays.asList(new File("/some/file")); },
+                        "arg", true, "[/some/file]"},
                 { new Object(){ @Argument(optional = true) File arg = new File(URI.create("file:///some/file")); }, "arg", true, "/some/file"},
+                { new Object(){ @Argument(optional = true) List<File> arg = Arrays.asList(new File(URI.create("file:///some/file"))); },
+                        "arg", true, "[/some/file]"},
 
         };
     }

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -161,4 +161,29 @@ public class NamedArgumentDefinitionUnitTest {
         throw new IllegalArgumentException("Can't find field");
     }
 
+    @Test
+    public void testFileFromUri(){
+        final String uri = "file:///some/file";
+        final String malformed = "file///some/file";
+        final File f = ArgumentDefinition.fileFromFileSchemeURI(uri);
+        Assert.assertEquals(f, new File("/some/file"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ArgumentDefinition.fileFromFileSchemeURI(malformed));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ArgumentDefinition.fileFromFileSchemeURI(null));
+    }
+    
+    @Test
+    public void testConstructFromStringForFiles(){
+        String uri = "file:///some/file";
+        String filePath = "/some/file";
+        String fieldName = "file";
+        
+        final Object o = new Object(){ @Argument(optional = false, shortName = "file") File file;};
+        final Field field = getFieldForFieldName(o, fieldName);
+        final ArgumentDefinition def = new NamedArgumentDefinition(field.getAnnotation(Argument.class), o, field, null);
+
+        //both the uri and the file path should result in the same file
+        Assert.assertEquals(def.constructFromString(uri, "file"), new File(filePath));
+        Assert.assertEquals(def.constructFromString(filePath, "file"), new File(filePath));
+    }
+
 }

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -170,6 +170,19 @@ public class NamedArgumentDefinitionUnitTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> ArgumentDefinition.fileFromFileSchemeURI(malformed));
         Assert.assertThrows(IllegalArgumentException.class, () -> ArgumentDefinition.fileFromFileSchemeURI(null));
     }
+
+    @Test
+    public void testFileFromEncodedUri(){
+        final String encoded = "file:///some/file%23foo";
+        final String decoded = "/some/file#foo";
+        final String encoded2 = "file:///some/file%3Ffoo";
+        final String decoded2 = "/some/file?foo";
+        final File f = ArgumentDefinition.fileFromFileSchemeURI(encoded);
+        final File f2 = ArgumentDefinition.fileFromFileSchemeURI(encoded2);
+
+        Assert.assertEquals(f, new File(decoded));
+        Assert.assertEquals(f2, new File(decoded2));
+    }
     
     @Test
     public void testConstructFromStringForFiles(){

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -65,7 +65,7 @@ public class NamedArgumentDefinitionUnitTest {
 
                 { new Object(){ @Argument(optional = false) File arg; }, "arg", false, NamedArgumentDefinition.NULL_ARGUMENT_STRING},
                 { new Object(){ @Argument(optional = true) File arg = new File("/some/file"); }, "arg", true, "/some/file"},
-                { new Object(){ @Argument(optional = true) File arg = new File(URI.create("file://some/file")); }, "arg", true, "/some/file"},
+                { new Object(){ @Argument(optional = true) File arg = new File(URI.create("file:///some/file")); }, "arg", true, "/some/file"},
 
         };
     }

--- a/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinitionUnitTest.java
@@ -183,7 +183,20 @@ public class NamedArgumentDefinitionUnitTest {
         Assert.assertEquals(f, new File(decoded));
         Assert.assertEquals(f2, new File(decoded2));
     }
-    
+
+    @Test
+    public void testUriTolerance(){
+        //test tolerance of illegal unencoded fragment (#) and query (?) uri characters
+        final String fragment = "file:///foo/baa#baz";
+        final String query = "file:///foo/baa?baz";
+        final File f1 = new File("/foo/baa#baz");
+        final File f2 = new File("/foo/baa?baz");
+
+        Assert.assertEquals(ArgumentDefinition.fileFromFileSchemeURI(fragment), f1);
+        Assert.assertEquals(ArgumentDefinition.fileFromFileSchemeURI(query), f2);
+
+    }
+
     @Test
     public void testConstructFromStringForFiles(){
         String uri = "file:///some/file";


### PR DESCRIPTION
The change allows programs like Picard to accept input arguments that are Strings representing either file paths or file scheme URIs.
For example when Picard is built with this new Barclay as a dependency the following are both possible:

`java -jar /Users/mrschre/dev/picard/build/libs/picard.jar SortVcf -I file:///Users/mrschre/dev/picard/testdata/picard/arrays/input.vcf -O file:///tmp/output.vcf`
as well as 
`java -jar /Users/mrschre/dev/picard/build/libs/picard.jar SortVcf -I /Users/mrschre/dev/picard/testdata/picard/arrays/input.vcf -O` /tmp/output.vcf`

Combinations of file paths and file schema URIs are also possible. 