### PR TITLE
Update test output for a test that was added in the previous branch that was merged.

### DIFF
--- a/src/test/resources/org/broadinstitute/barclay/help/expected/WDLDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.wdl
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/WDLDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.wdl
@@ -166,6 +166,7 @@ workflow TestArgumentContainer {
     positionalArgs: { description: "Positional arguments, min = 2, max = 2" }
 
     # Required Arguments
+    enumCollection: { description: "Undocumented option" }
     requiredClpEnum: { description: "Required Clp enum" }
     requiredFileList: { description: "Required file list" }
     companionDictionary: { description: "Companion resource for requiredFileList" }
@@ -286,6 +287,7 @@ task TestArgumentContainer {
     positionalArgs: { description: "Positional arguments, min = 2, max = 2" }
 
     # Required Arguments
+    enumCollection: { description: "Undocumented option" }
     requiredClpEnum: { description: "Required Clp enum" }
     requiredFileList: { description: "Required file list" }
     companionDictionary: { description: "Companion resource for requiredFileList" }


### PR DESCRIPTION
The previous branch (https://github.com/broadinstitute/barclay/pull/165, with WDL updates) added a new test, but the test output for that new test has to be updated to reflect the changes that were made to the input files in the last branch (https://github.com/broadinstitute/barclay/pull/160) so the tests on master will pass. (All of the WDL/Doc/Tab generation tests share the same test inputs - when changing a test input, often all of the test outputs need to be updated).