### PR TITLE
Fix mutable HelpDoclet member declarations.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/BashTabCompletionDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/BashTabCompletionDoclet.java
@@ -250,12 +250,6 @@ public class BashTabCompletionDoclet extends HelpDoclet {
 
     // =============================================
 
-    // Member variables:
-    protected static String outputFileExtension = "sh";
-    protected static String indexFileExtension = "sh";
-
-    // =============================================
-
     public static boolean start(RootDoc rootDoc) {
         try {
             return new BashTabCompletionDoclet().startProcessDocs(rootDoc);

--- a/src/main/java/org/broadinstitute/barclay/help/DocWorkUnitHandler.java
+++ b/src/main/java/org/broadinstitute/barclay/help/DocWorkUnitHandler.java
@@ -52,7 +52,7 @@ public abstract class DocWorkUnitHandler {
      * @return the name of the destination file to which documentation output will be written
      */
     public String getDestinationFilename(final DocWorkUnit workUnit) {
-        return DocletUtils.phpFilenameForClass(workUnit.getClazz(), HelpDoclet.outputFileExtension);
+        return DocletUtils.phpFilenameForClass(workUnit.getClazz(), getDoclet().outputFileExtension);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
+++ b/src/main/java/org/broadinstitute/barclay/help/HelpDoclet.java
@@ -80,14 +80,14 @@ public class HelpDoclet {
     // Variables that are set on the command line when running javadoc
     //
     // ----------------------------------------------------------------------
-    protected static File settingsDir = DEFAULT_SETTINGS_DIR;
+    protected File settingsDir = DEFAULT_SETTINGS_DIR;
     protected boolean isSettingsDirSet = false;
-    protected static File destinationDir = DEFAULT_DESTINATION_DIR;
-    protected static String outputFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
-    protected static String indexFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
-    protected static String buildTimestamp = "[no timestamp available]";
-    protected static String absoluteVersion = "[no version available]";
-    protected static boolean showHiddenFeatures = false;
+    protected File destinationDir = DEFAULT_DESTINATION_DIR;
+    protected String outputFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
+    protected String indexFileExtension = DEFAULT_OUTPUT_FILE_EXTENSION;
+    protected String buildTimestamp = "[no timestamp available]";
+    protected String absoluteVersion = "[no version available]";
+    protected boolean showHiddenFeatures = false;
     protected boolean useDefaultTemplates = false;
 
     // Variables to store data for Freemarker:


### PR DESCRIPTION
Make some static `HelpDoclet` members that were mutable into instance variables to prevent residual side effects from causing random test failures when tests are run serially.
