### PR TITLE
Fix command line data type display to not use an embedded colon.

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinition.java
+++ b/src/main/java/org/broadinstitute/barclay/argparser/NamedArgumentDefinition.java
@@ -443,7 +443,7 @@ public class NamedArgumentDefinition extends ArgumentDefinition {
             sb.append(",-").append(getShortName());
         }
 
-        sb.append(":").append(getUnderlyingFieldClass().getSimpleName());
+        sb.append(String.format(" <%s>", getUnderlyingFieldClass().getSimpleName()));
 
         int labelLength = sb.toString().length();
         int numSpaces = argumentColumnWidth - labelLength;

--- a/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/broadinstitute/barclay/argparser/CommandLineArgumentParserTest.java
@@ -96,6 +96,32 @@ public final class CommandLineArgumentParserTest {
         public String OSCILLATION_FREQUENCY;
     }
 
+    @DataProvider(name="argUsageCases")
+    public Object[][] argUsageCases() {
+        return new Object[][]{
+                {
+                    new FrobnicateArguments(), Arrays.asList(
+                        "--FROBNICATION_FLAVOR <FrobnicationFlavor>",
+                        "--SHMIGGLE_TYPE <String>",
+                        "--arguments_file <File>",
+                        "--FROBNICATION_THRESHOLD,-T <Integer>",
+                        "--TRUTHINESS <Boolean>")
+                },
+                {
+                    new MixedCardinalityMutexArguments(), Arrays.asList(
+                        "--collection <String>",
+                        "--scalar <String>")
+                }
+        };
+    }
+
+    @Test(dataProvider = "argUsageCases")
+    public void testArgUsage(final Object argContainer, final List<String> expectedUsageStrings) {
+        final CommandLineArgumentParser clp = new CommandLineArgumentParser(argContainer);
+        final String usageString = clp.usage(true, false);
+        expectedUsageStrings.forEach(s -> Assert.assertTrue(usageString.contains(s)));
+    }
+
     @Test
     public void testRequiredOnlyUsage() {
         final RequiredOnlyArguments nr = new RequiredOnlyArguments();


### PR DESCRIPTION
The command line help for the Barclay parser uses a hybrid display format left over from the legacy parser (`--input:GATKPath`), which is confusing when Barclay parser syntax is being used. This changes the display syntax for the Barclay parser to use `--input <GATKPath>`, i.e.:

```
Required Arguments:

--input,-I <GATKPath>         BAM/SAM/CRAM file containing reads  This argument must be specified at least once.
                              Required. 

--output,-O <GATKPath>        Write output to this file  Required. 
...
```


See GATK https://github.com/broadinstitute/gatk/issues/6775.