### PR TITLE
Fix reversed logic in the help template.

### DIFF
--- a/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.html.ftl
+++ b/src/main/resources/org/broadinstitute/barclay/helpTemplates/generic.html.ftl
@@ -60,9 +60,9 @@
 		<#if arg.options?has_content>
 			<p>
 		<#if arg.collection>
-				The ${arg.name} argument is an enumerated type (${arg.type}), which can accept the following values:
-		<#else>
 				The ${arg.name} argument is a list of an enumerated type (${arg.type}), which can accept one or more of the following values:
+		<#else>
+				The ${arg.name} argument is an enumerated type (${arg.type}), which can accept the following values:
 		</#if>
 			<dl class="enum">
 				<#list arg.options as option>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.html
@@ -402,7 +402,7 @@ Undocumented option</b><br />
 			
 		</p>
 			<p>
-				The --enumCollection argument is an enumerated type (List[TestEnum]), which can accept the following values:
+				The --enumCollection argument is a list of an enumerated type (List[TestEnum]), which can accept one or more of the following values:
 			<dl class="enum">
 					<dt class="enum">ENUM_VALUE_1</dt>
 					<dd class="enum">This is enum value 1.</dd>
@@ -425,7 +425,7 @@ Some set thing.</b><br />
 			
 		</p>
 			<p>
-				The --enumSetLong argument is an enumerated type (EnumSet[TestEnum]), which can accept the following values:
+				The --enumSetLong argument is a list of an enumerated type (EnumSet[TestEnum]), which can accept one or more of the following values:
 			<dl class="enum">
 					<dt class="enum">ENUM_VALUE_1</dt>
 					<dd class="enum">This is enum value 1.</dd>
@@ -525,7 +525,7 @@ Optional Clp enum</b><br />
 			
 		</p>
 			<p>
-				The --optionalClpEnum argument is a list of an enumerated type (TestEnum), which can accept one or more of the following values:
+				The --optionalClpEnum argument is an enumerated type (TestEnum), which can accept the following values:
 			<dl class="enum">
 					<dt class="enum">ENUM_VALUE_1</dt>
 					<dd class="enum">This is enum value 1.</dd>
@@ -640,7 +640,7 @@ Required Clp enum</b><br />
 			
 		</p>
 			<p>
-				The --requiredClpEnum argument is a list of an enumerated type (TestEnum), which can accept one or more of the following values:
+				The --requiredClpEnum argument is an enumerated type (TestEnum), which can accept the following values:
 			<dl class="enum">
 					<dt class="enum">ENUM_VALUE_1</dt>
 					<dd class="enum">This is enum value 1.</dd>

--- a/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.html
+++ b/src/test/resources/org/broadinstitute/barclay/help/expected/HelpDoclet/org_broadinstitute_barclay_help_testinputs_TestArgumentContainer.html
@@ -502,7 +502,7 @@ Undocumented option</b><br />
 			
 		</p>
 			<p>
-				The --nonCLPEnumCollection argument is an enumerated type (List[TestNonCLPEnum]), which can accept the following values:
+				The --nonCLPEnumCollection argument is a list of an enumerated type (List[TestNonCLPEnum]), which can accept one or more of the following values:
 			<dl class="enum">
 					<dt class="enum">NON_CLP_ENUM_VALUE_1</dt>
 					<dd class="enum">This is the NON_CLP_ENUM_VALUE_1 comment</dd>


### PR DESCRIPTION
This template is only used for testing Barclay, but its still wrong.