### PR TITLE
adding a null check to avoid NPE in picard

### DIFF
--- a/src/main/java/org/broadinstitute/barclay/help/scanners/UnknownInlineTagScanner.java
+++ b/src/main/java/org/broadinstitute/barclay/help/scanners/UnknownInlineTagScanner.java
@@ -41,7 +41,7 @@ public class UnknownInlineTagScanner extends DocTreeScanner<Void, Void> {
 
         // unknown inline tags might be custom tags, so break them down and return the parts
         // for the caller to parse
-        if (t.getKind().equals(DocTree.Kind.UNKNOWN_INLINE_TAG)) {
+        if (t != null && t.getKind().equals(DocTree.Kind.UNKNOWN_INLINE_TAG)) {
             final UnknownInlineTagTree tagTree = (UnknownInlineTagTree) t;
             final List<String> tagParts = tagTree.getContent().stream().map(Object::toString).toList();
             inlineTags.put(tagTree.getTagName(), tagParts);


### PR DESCRIPTION
This *seems* to fix a bug in picard when running picard docs with java 21.  The docs pass and look reasonable with it instead of exploding with an NPE.

```
java.lang.NullPointerException: Cannot invoke "com.sun.source.doctree.DocTree.getKind()" because "t" is null
        at org.broadinstitute.barclay.help.scanners.UnknownInlineTagScanner.scan(UnknownInlineTagScanner.java:44)
        at org.broadinstitute.barclay.help.scanners.UnknownInlineTagScanner.scan(UnknownInlineTagScanner.java:18)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.visitValue(DocTreeScanner.java:680)
        at jdk.compiler/com.sun.tools.javac.tree.DCTree$DCValue.accept(DCTree.java:1402)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.scan(DocTreeScanner.java:90)
        at org.broadinstitute.barclay.help.scanners.UnknownInlineTagScanner.scan(UnknownInlineTagScanner.java:50)
        at org.broadinstitute.barclay.help.scanners.UnknownInlineTagScanner.scan(UnknownInlineTagScanner.java:18)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.scanAndReduce(DocTreeScanner.java:94)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.scan(DocTreeScanner.java:109)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.scanAndReduce(DocTreeScanner.java:117)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.visitDocComment(DocTreeScanner.java:205)
        at jdk.compiler/com.sun.tools.javac.tree.DCTree$DCDocComment.accept(DCTree.java:358)
        at jdk.compiler/com.sun.source.util.DocTreeScanner.scan(DocTreeScanner.java:90)
        at org.broadinstitute.barclay.help.scanners.UnknownInlineTagScanner.scan(UnknownInlineTagScanner.java:50)
        at org.broadinstitute.barclay.help.scanners.JavaLanguageModelScanners.getUnknownInlineTags(JavaLanguageModelScanners.java:140)
        at org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler.addCustomBindings(DefaultDocWorkUnitHandler.java:257)
        at picard.util.help.PicardHelpDocWorkUnitHandler.addCustomBindings(PicardHelpDocWorkUnitHandler.java:74)
        at org.broadinstitute.barclay.help.DefaultDocWorkUnitHandler.processWorkUnit(DefaultDocWorkUnitHandler.java:208)
        at org.broadinstitute.barclay.help.DocWorkUnit.processDoc(DocWorkUnit.java:168)
        at org.broadinstitute.barclay.help.HelpDoclet.lambda$processDocs$1(HelpDoclet.java:305)
        at java.base/java.util.TreeMap$KeySpliterator.forEachRemaining(TreeMap.java:3099)
        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        at org.broadinstitute.barclay.help.HelpDoclet.processDocs(HelpDoclet.java:305)
        at org.broadinstitute.barclay.help.HelpDoclet.run(HelpDoclet.java:113)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:575)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:398)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:347)
        at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:57)
        at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:46)
```

I don't really understand what's going on though so this really needs more investigation / a test before it goes in I think.