### PR TITLE
Update gradle to 8.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 wrapper {
-    gradleVersion = '8.5'
+    gradleVersion = '8.12'
 }
 
 java {
@@ -24,7 +24,7 @@ version = (isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT").replaceAll(".d
 repositories {
     mavenCentral()
     maven {
-        url "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for Broad snapshots
+        url = "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for Broad snapshots
     }
 
     mavenLocal()
@@ -123,7 +123,7 @@ artifacts {
  * Sign non-snapshot releases with our secret key.  This should never need to be invoked directly.
  */
 signing {
-    required { isRelease && gradle.taskGraph.hasTask("publish") }
+    required = (isRelease && gradle.taskGraph.hasTask("publish"))
     sign publishing.publications
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
@cmnbroad Gradle is removing the magic syntax `properyName value`.  Apparently that's a gradle specific thing and not groovy.  

Currently you can set a property with any of these mechanisms:

propertyName = value
setPropertyName(value)
setPropertyName value
propertyName(value)
propertyName value

But now it will just be these which are the standard groovy options, either implicitly call the setter using the standard setter, or call the setter explicitly.  

propertyName = value
setPropertyName(value)
setPropertyName value

This has confused the hell out of me for years, so good riddance!