### PR TITLE
DDO-4137 read from GAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ version = (isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT").replaceAll(".d
 repositories {
     mavenCentral()
     maven {
+        // Note: We are still publishing to JFrog, but consuming artifacts from GAR. This interim state works because
+        // a background kubernetes job syncs new artifacts from JFrog to GAR within 5 minutes.
         url = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/" //for Broad snapshots
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ version = (isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT").replaceAll(".d
 repositories {
     mavenCentral()
     maven {
-        url = "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/" //for Broad snapshots
+        url = "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/" //for Broad snapshots
     }
 
     mavenLocal()


### PR DESCRIPTION
JIRA ticket https://broadworkbench.atlassian.net/browse/DDO-4137


**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Will rely on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline (where they exist) failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).